### PR TITLE
Fix codemod crash on annotations without assignment

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "python.pythonPath": "~/.pyenv/shims/python",
   "editor.formatOnSave": true,
   "files.exclude": {
     "**/*.pyc": true,
@@ -17,12 +16,7 @@
   "python.testing.nosetestsEnabled": false,
 
   "python.formatting.provider": "yapf",
-  "python.formatting.autopep8Args": [
-      "--max-line-length",
-      "120"
-  ],
-  "python.testing.pytestArgs": [
-    "."
-  ],
+  "python.formatting.autopep8Args": ["--max-line-length", "120"],
+  "python.testing.pytestArgs": ["."],
   "python.linting.pylintEnabled": true
 }

--- a/codemod/remove_types.py
+++ b/codemod/remove_types.py
@@ -1,6 +1,8 @@
 import argparse
 import libcst as cst
 from libcst import matchers as m, codemod
+
+
 class RemoveTypesTransformer(codemod.VisitorBasedCodemodCommand):
 
     DESCRIPTION = "Removes annotations."
@@ -8,15 +10,19 @@ class RemoveTypesTransformer(codemod.VisitorBasedCodemodCommand):
     def leave_Param(self, original_node: cst.Param, updated_node: cst.Param):
         return updated_node.with_changes(annotation=None)
 
-    def leave_FunctionDef(
-        self,
-        original_node: cst.FunctionDef,
-        updated_node: cst.FunctionDef
-    ):
+    def leave_FunctionDef(self, original_node: cst.FunctionDef,
+                          updated_node: cst.FunctionDef):
         return updated_node.with_changes(returns=None)
 
-    def leave_AnnAssign(self, original_node: cst.AnnAssign, updated_node: cst.AnnAssign):
+    def leave_AnnAssign(self, original_node: cst.AnnAssign,
+                        updated_node: cst.AnnAssign):
+        if updated_node.value is None:
+            # e.g. `some_var: str`
+
+            # these are *only* type declarations and have no runtime behavior,
+            # so they should be removed entirely:
+            return cst.RemoveFromParent()
+
         return cst.Assign(
             targets=[cst.AssignTarget(target=updated_node.target)],
-            value=updated_node.value
-        )
+            value=updated_node.value)

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -64,9 +64,8 @@ class Settings(six.with_metaclass(CantTouchThis, object)):
 
     # pylint: disable=no-member
 
-    # TODO(david): fix codemod to handle this?
-    # team: Optional[str]
-    # entity: Optional[str]
+    team: Optional[str]
+    entity: Optional[str]
 
     def __init__(  # pylint: disable=unused-argument
         self,

--- a/wandb/sdk_py27/wandb_settings.py
+++ b/wandb/sdk_py27/wandb_settings.py
@@ -62,12 +62,6 @@ class Settings(six.with_metaclass(CantTouchThis, object)):
 
     """
 
-    # pylint: disable=no-member
-
-    # TODO(david): fix codemod to handle this?
-    # team: Optional[str]
-    # entity: Optional[str]
-
     def __init__(  # pylint: disable=unused-argument
         self,
         team = None,


### PR DESCRIPTION
The type-annotation-removal codemod will now remove entire annotation assignment nodes when they contain only an annotation and no actual assignment.