### PR TITLE
Switch cli-ng to its own sentry project, and clean up instrumentation

### DIFF
--- a/wandb/internal/internal.py
+++ b/wandb/internal/internal.py
@@ -20,6 +20,7 @@ import wandb
 from wandb.interface import constants
 from wandb.internal import datastore
 from wandb.internal import sender
+from wandb.util import sentry_exc
 
 # from wandb.stuff import io_wrap
 
@@ -65,7 +66,8 @@ def wandb_stream_read(fd):
     while True:
         try:
             data = os.read(fd, 200)
-        except OSError:
+        except OSError as e:
+            sentry_exc(e)
             # print("problem", e, file=sys.stderr)
             return
         if len(data) == 0:

--- a/wandb/internal/sender.py
+++ b/wandb/internal/sender.py
@@ -11,6 +11,7 @@ import logging
 import os
 import time
 
+from wandb.util import sentry_set_scope
 from wandb.proto import wandb_internal_pb2  # type: ignore
 
 # from wandb.stuff import io_wrap
@@ -152,6 +153,7 @@ class SendManager(object):
         self._fs.start()
         self._pusher = FilePusher(self._api)
         self._run_id = run.run_id
+        sentry_set_scope("internal", run.entity, run.project)
         logger.info("run started: %s", self._run_id)
 
     def handle_history(self, data):

--- a/wandb/internal/sender.py
+++ b/wandb/internal/sender.py
@@ -11,8 +11,8 @@ import logging
 import os
 import time
 
-from wandb.util import sentry_set_scope
 from wandb.proto import wandb_internal_pb2  # type: ignore
+from wandb.util import sentry_set_scope
 
 # from wandb.stuff import io_wrap
 

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -21,6 +21,7 @@ from wandb.errors import Error
 from wandb.lib import filesystem, redirect, reporting
 from wandb.lib.globals import set_global
 from wandb.old import io_wrap
+from wandb.util import sentry_reraise, sentry_exc
 
 from .wandb_run import Run, RunDummy, RunManaged
 from .wandb_settings import Settings
@@ -532,7 +533,9 @@ def init(
         wi.setup(kwargs)
         try:
             run = wi.init()
-        except (KeyboardInterrupt, Exception):
+        except (KeyboardInterrupt, Exception) as e:
+            if not isinstance(e, KeyboardInterrupt):
+                sentry_exc(e)
             getcaller()
             assert logger
             logger.exception("we got issues")
@@ -549,6 +552,9 @@ def init(
     except Exception as e:
         assert logger
         logger.error("error", exc_info=e)
+        # Need to build delay into this sentry capture because our exit hooks
+        # mess with sentry's ability to send out errors before the program ends.
+        sentry_exc(e, delay=True)
         raise_from(Exception("problem"), e)
 
     return run

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -21,7 +21,7 @@ from wandb.errors import Error
 from wandb.lib import filesystem, redirect, reporting
 from wandb.lib.globals import set_global
 from wandb.old import io_wrap
-from wandb.util import sentry_reraise, sentry_exc
+from wandb.util import sentry_exc
 
 from .wandb_run import Run, RunDummy, RunManaged
 from .wandb_settings import Settings

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -16,6 +16,7 @@ import shutil
 import click
 import wandb
 from wandb.data_types import _datatypes_set_callback
+from wandb.util import sentry_set_scope
 from wandb.viz import Visualize
 
 from . import wandb_config
@@ -63,6 +64,10 @@ class RunManaged(Run):
 
         # Pull info from settings
         self._init_from_settings(settings)
+
+        # Initial scope setup for sentry. This might get changed when the
+        # actual run comes back.
+        sentry_set_scope("user", self._entity, self._project)
 
         # Returned from backend send_run_sync, set from wandb_init?
         self._run_obj = None
@@ -205,6 +210,8 @@ class RunManaged(Run):
 
     def _set_run_obj(self, run_obj):
         self._run_obj = run_obj
+        # TODO: It feels weird to call this twice..
+        sentry_set_scope("user", run_obj.entity, run_obj.project, self._get_run_url())
 
     def log(self, data, step=None, commit=True):
         if commit:

--- a/wandb/sdk_py27/wandb_run.py
+++ b/wandb/sdk_py27/wandb_run.py
@@ -16,6 +16,7 @@ import shutil
 import click
 import wandb
 from wandb.data_types import _datatypes_set_callback
+from wandb.util import sentry_set_scope
 from wandb.viz import Visualize
 
 from . import wandb_config
@@ -63,6 +64,10 @@ class RunManaged(Run):
 
         # Pull info from settings
         self._init_from_settings(settings)
+
+        # Initial scope setup for sentry. This might get changed when the
+        # actual run comes back.
+        sentry_set_scope("user", self._entity, self._project)
 
         # Returned from backend send_run_sync, set from wandb_init?
         self._run_obj = None
@@ -205,6 +210,8 @@ class RunManaged(Run):
 
     def _set_run_obj(self, run_obj):
         self._run_obj = run_obj
+        # TODO: It feels weird to call this twice..
+        sentry_set_scope("user", run_obj.entity, run_obj.project, self._get_run_url())
 
     def log(self, data, step=None, commit=True):
         if commit:

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -36,6 +36,7 @@ from importlib import import_module
 import sentry_sdk
 from sentry_sdk import capture_exception
 from sentry_sdk import capture_message
+from sentry_sdk import configure_scope
 from wandb.env import error_reporting_enabled
 
 import wandb
@@ -60,7 +61,7 @@ else:
     SENTRY_ENV = 'production'
 
 if error_reporting_enabled():
-    sentry_sdk.init("https://f84bb3664d8e448084801d9198b771b2@sentry.io/1299483",
+    sentry_sdk.init(dsn="https://a2f1d701163c42b097b9588e56b1c37e@o151352.ingest.sentry.io/5288891",
                     release=wandb.__version__,
                     default_integrations=False,
                     environment=SENTRY_ENV)
@@ -71,12 +72,14 @@ def sentry_message(message):
         capture_message(message)
 
 
-def sentry_exc(exc):
+def sentry_exc(exc, delay=False):
     if error_reporting_enabled():
         if isinstance(exc, six.string_types):
-            capture_exception(Exception(exc))
+            sentry_sdk.capture_exception(Exception(exc))
         else:
-            capture_exception(exc)
+            sentry_sdk.capture_exception(exc)
+        if delay:
+            time.sleep(2)
 
 
 def sentry_reraise(exc):
@@ -90,6 +93,15 @@ def sentry_reraise(exc):
     # this will messily add this "reraise" function to the stack trace
     # but hopefully it's not too bad
     six.reraise(type(exc), exc, sys.exc_info()[2])
+
+
+def sentry_set_scope(process_context, entity, project, url=None):
+    with configure_scope() as scope:
+        scope.set_tag("process_context", process_context)
+        scope.set_tag("entity", entity)
+        scope.set_tag("project", project)
+        if url is not None:
+            scope.set_tag("url", url)
 
 
 def vendor_import(name):

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -75,9 +75,9 @@ def sentry_message(message):
 def sentry_exc(exc, delay=False):
     if error_reporting_enabled():
         if isinstance(exc, six.string_types):
-            sentry_sdk.capture_exception(Exception(exc))
+            capture_exception(Exception(exc))
         else:
-            sentry_sdk.capture_exception(exc)
+            capture_exception(exc)
         if delay:
             time.sleep(2)
 


### PR DESCRIPTION
- Made a new sentry project for cling.
- Sprinkled in some some sentry_exc/sentry_reraise where I thought it made sense.
- Added in a delay when capturing a toplevel exception during init. The delay is necessary because our atexit hooks interfere with sentry's (which essentially just wait for up to 2 seconds for exceptions to finish sending).