### PR TITLE
[Enhancement] Add empty defaults for point cloud scene

### DIFF
--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -477,9 +477,9 @@ class Object3D(BatchableMedia):
             if data_or_path['type'] == 'lidar/beta':
                 data = {
                     'type': data_or_path['type'],
-                    'vectors': data_or_path['vectors'].tolist(),
-                    'points': data_or_path['points'].tolist(),
-                    'boxes': data_or_path['boxes'].tolist(),
+                    'vectors': data_or_path['vectors'].tolist() if 'vectors' in data_or_path else [],
+                    'points': data_or_path['points'].tolist() if 'points' in data_or_path else [],
+                    'boxes': data_or_path['boxes'].tolist() if 'boxes' in data_or_path else [],
                 }
             else:
                 raise ValueError("Type not supported, only 'lidar/beta' is currently supported")


### PR DESCRIPTION
This allows users to create point cloud scenes with only one of the necessary data types.