### PR TITLE
Fix bug that always used temp dir if dir was unspecified

### DIFF
--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -526,4 +526,4 @@ class Settings(six.with_metaclass(CantTouchThis, object)):
 
         self.update(args)
         self.run_id = self.run_id or _generate_id()
-        self.wandb_dir = get_wandb_dir(self.root_dir or "")
+        self.wandb_dir = get_wandb_dir(self.root_dir or ".")

--- a/wandb/sdk_py27/wandb_settings.py
+++ b/wandb/sdk_py27/wandb_settings.py
@@ -523,4 +523,4 @@ class Settings(six.with_metaclass(CantTouchThis, object)):
 
         self.update(args)
         self.run_id = self.run_id or _generate_id()
-        self.wandb_dir = get_wandb_dir(self.root_dir or "")
+        self.wandb_dir = get_wandb_dir(self.root_dir or ".")


### PR DESCRIPTION
Using `""` as the default `root_dir` had the effect of making `os.access(root_dir, os.W_OK) == False`. I'm not sure if this is the "right" solution, though -- it visibly changes the output as seen below...
![image](https://user-images.githubusercontent.com/1735971/88241898-62748c80-cc40-11ea-900c-4f974cf34763.png)

So there's a `.` in there now. I'm not sure yet why this didn't happen in cli-og.