### PR TITLE
Reload workspace settings

### DIFF
--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -329,6 +329,12 @@ class Settings(six.with_metaclass(CantTouchThis, object)):
             _logger.info("setting env: {}".format(env_dict))
             self.update(env_dict, _setter="env")
 
+    def _load_from_workspace(self):
+        settings_workspace = self._path_convert(
+            self.__dict__.get("settings_workspace_spec")
+        )
+        self.update(self._load(settings_workspace), _setter="workspace")
+
     def _path_convert_part(self, path_part, format_dict):
         """convert slashes, expand ~ and other macros."""
 
@@ -525,3 +531,4 @@ class Settings(six.with_metaclass(CantTouchThis, object)):
         self.update(args)
         self.run_id = self.run_id or generate_id()
         self.wandb_dir = get_wandb_dir(self.root_dir or ".")
+        self._load_from_workspace()

--- a/wandb/sdk_py27/wandb_settings.py
+++ b/wandb/sdk_py27/wandb_settings.py
@@ -326,6 +326,12 @@ class Settings(six.with_metaclass(CantTouchThis, object)):
             _logger.info("setting env: {}".format(env_dict))
             self.update(env_dict, _setter="env")
 
+    def _load_from_workspace(self):
+        settings_workspace = self._path_convert(
+            self.__dict__.get("settings_workspace_spec")
+        )
+        self.update(self._load(settings_workspace), _setter="workspace")
+
     def _path_convert_part(self, path_part, format_dict):
         """convert slashes, expand ~ and other macros."""
 
@@ -522,3 +528,4 @@ class Settings(six.with_metaclass(CantTouchThis, object)):
         self.update(args)
         self.run_id = self.run_id or generate_id()
         self.wandb_dir = get_wandb_dir(self.root_dir or ".")
+        self._load_from_workspace()


### PR DESCRIPTION
Fixes the issue wherein the project setting in the local wandb/settings file wasn't being respected -- and probably a few other similar issues we hadn't caught yet.

This might be a hacky fix, and it doesn't address the fact that the settings loading is still distributed across the old and new systems. 