### PR TITLE
Re-enable auto_project_name logic

### DIFF
--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -419,7 +419,7 @@ def sweep(ctx, project, entity, controller, verbose, name, program, settings, up
     env = os.environ
     entity = entity or env.get("WANDB_ENTITY") or config.get('entity')
     project = project or env.get("WANDB_PROJECT") or config.get('project') or util.auto_project_name(
-        config.get("program"), api)
+        config.get("program"))
     sweep_id = api.upsert_sweep(config, project=project, entity=entity, obj_id=sweep_obj_id)
     wandb.termlog('{} sweep with ID: {}'.format(
         'Updated' if sweep_obj_id else 'Created',

--- a/wandb/internal/internal_api.py
+++ b/wandb/internal/internal_api.py
@@ -779,7 +779,8 @@ class Api(object):
             kwargs['num_retries'] = num_retries
 
         variable_values = {
-            'id': id, 'entity': entity or self.settings('entity'), 'name': name, 'project': project,
+            'id': id, 'entity': entity or self.settings('entity'), 'name': name,
+            'project': project or util.auto_project_name(program_path),
             'groupName': group, 'tags': tags,
             'description': description, 'config': config, 'commit': commit,
             'displayName': display_name, 'notes': notes,

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -44,6 +44,7 @@ import wandb
 import wandb.old.core
 from wandb.old.core import wandb_dir
 from wandb.errors.error import CommError
+from wandb.internal.git_repo import GitRepo
 # from wandb import wandb_config
 from wandb import env
 
@@ -898,9 +899,10 @@ def sizeof_fmt(num, suffix='B'):
     return "%.1f%s%s" % (num, 'Yi', suffix)
 
 
-def auto_project_name(program, api):
+def auto_project_name(program):
     # if we're in git, set project name to git repo name + relative path within repo
-    root_dir = api.git.root_dir
+    repo = GitRepo()
+    root_dir = repo.root_dir
     if root_dir is None:
         return None
     repo_name = os.path.basename(root_dir)


### PR DESCRIPTION
Tested with a project with no wandb folder where the runs were previously going to "uncategorized", and also with a sweep that had no prior config.