### PR TITLE
[Bugfix] Fixes media issues

### DIFF
--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -52,9 +52,6 @@ def test_bind_image(mocked_run):
     wb_image.bind_to_run(mocked_run, 'stuff', 10)
     assert wb_image.is_bound()
 
-    with pytest.raises(RuntimeError):
-        wb_image.bind_to_run(mocked_run, 'stuff', 10)
-
 
 full_box = {
     "position": {

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -270,7 +270,7 @@ class Table(Media):
         self.data = list(rows or data or [])
         if dataframe is not None:
             assert util.is_pandas_data_frame(dataframe), 'dataframe argument expects a `Dataframe` object'
-            self.columns = dataframe.columns.tolist()
+            self.columns = list(dataframe.columns)
             self.data = []
             for row in range(len(dataframe)):
                 self.add_data(*tuple(dataframe[col].values[row] for col in self.columns))

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -26,7 +26,6 @@ import uuid
 import json
 import codecs
 import tempfile
-import re
 from wandb import util
 from wandb.util import has_num
 from wandb.compat import tempfile

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -26,6 +26,7 @@ import uuid
 import json
 import codecs
 import tempfile
+import re
 from wandb import util
 from wandb.util import has_num
 from wandb.compat import tempfile
@@ -49,6 +50,9 @@ def _datatypes_callback(fname):
     if _glob_datatypes_callback:
         _glob_datatypes_callback(fname)
 # cling above
+
+def wb_filename(key, step, id, extension):
+    return  '{}_{}_{}{}'.format(key, step, id, extension)
 
 
 class WBValue(object):
@@ -183,39 +187,33 @@ class Media(WBValue):
             raise AssertionError('bind_to_run called before _set_file')
         if run is None:
             raise TypeError('Argument "run" must not be None.')
-        if self.is_bound():
-            raise RuntimeError('Value is already bound to a Run: {}'.format(self))
         self._run = run
 
-        # This is a flawed way of checking whether the file is already in
-        # the Run directory. It'd be better to check the actual directory
-        # components.
-        if not os.path.realpath(self._path).startswith(os.path.realpath(self._run.dir)):
-            base_path = os.path.join(self._run.dir, self.get_media_subdir())
+        base_path = os.path.join(self._run.dir, self.get_media_subdir())
 
-            if self._extension is None:
-                rootname, extension = os.path.splitext(os.path.basename(self._path))
-            else:
-                extension = self._extension
-                rootname = os.path.basename(self._path)[:-len(extension)]
+        if self._extension is None:
+            rootname, extension = os.path.splitext(os.path.basename(self._path))
+        else:
+            extension = self._extension
+            rootname = os.path.basename(self._path)[:-len(extension)]
 
-            if id_ is None:
-                id_ = self._sha256[:8]
+        if id_ is None:
+            id_ = self._sha256[:8]
 
-            file_path = '{}_{}_{}{}'.format(key, step, id_, extension)
-            media_path = os.path.join(self.get_media_subdir(), file_path)
-            new_path = os.path.join(base_path, file_path)
-            util.mkdir_exists_ok(os.path.dirname(new_path))
+        file_path = wb_filename(key, step, id_, extension)
+        media_path = os.path.join(self.get_media_subdir(), file_path)
+        new_path = os.path.join(base_path, file_path)
+        util.mkdir_exists_ok(os.path.dirname(new_path))
 
-            if self._is_tmp:
-                shutil.move(self._path, new_path)
-                self._path = new_path
-                self._is_tmp = False
-                _datatypes_callback(media_path)
-            else:
-                shutil.copy(self._path, new_path)
-                self._path = new_path
-                _datatypes_callback(media_path)
+        if self._is_tmp:
+            shutil.move(self._path, new_path)
+            self._path = new_path
+            self._is_tmp = False
+            _datatypes_callback(media_path)
+        else:
+            shutil.copy(self._path, new_path)
+            self._path = new_path
+            _datatypes_callback(media_path)
 
     def to_json(self, run):
         """Get the JSON-friendly dict that represents this object.
@@ -273,7 +271,7 @@ class Table(Media):
         self.data = list(rows or data or [])
         if dataframe is not None:
             assert util.is_pandas_data_frame(dataframe), 'dataframe argument expects a `Dataframe` object'
-            self.columns = dataframe.columns.to_list()
+            self.columns = dataframe.columns.tolist()
             self.data = []
             for row in range(len(dataframe)):
                 self.add_data(*tuple(dataframe[col].values[row] for col in self.columns))
@@ -879,6 +877,8 @@ class Image(BatchableMedia):
         if isinstance(data_or_path, six.string_types):
             self._set_file(data_or_path, is_tmp=False)
             self._image = PILImage.open(data_or_path)
+            ext = os.path.splitext(data_or_path)[1][1:]
+            self.format = ext
         else:
             data = data_or_path
 
@@ -906,6 +906,7 @@ class Image(BatchableMedia):
 
             tmp_path = os.path.join(
                 MEDIA_TMP.name, util.generate_id() + '.png')
+            self.format = "png"
             self._image.save(tmp_path, transparency=None)
             self._set_file(tmp_path, is_tmp=True)
 
@@ -928,7 +929,7 @@ class Image(BatchableMedia):
     def to_json(self, run):
         json_dict = super(Image, self).to_json(run)
         json_dict['_type'] = 'image-file'
-        json_dict['format'] = "png"
+        json_dict['format'] = self.format
 
         if self._width is not None:
             json_dict['width'] = self._width
@@ -993,8 +994,10 @@ class Image(BatchableMedia):
 
         jsons = [obj.to_json(run) for obj in images]
 
+        media_dir = cls.get_media_subdir()
+
         for obj in jsons:
-            expected = util.to_forward_slash_path(cls.get_media_subdir())
+            expected = util.to_forward_slash_path(media_dir)
             if not obj['path'].startswith(expected):
                 raise ValueError('Files in an array of Image\'s must be in the {} directory, not {}'.format(
                     cls.get_media_subdir(), obj['path']))


### PR DESCRIPTION
I split out the bugfixes from the test PR so they can be merged sooner.

1. Fixes an issue where a `wandb.Image` object could not be reused in an image array. Our `seq_to_json` code relies on a pattern, but if the image is already logged in a different step, its path is set to something different than expected. Now bind_to_run when be called for an object every time it's logged.

    This has the downside of uploading a file multiple times even if it is the same file, but that downside was already there with the spriting approach in cli-original. Since we want to keep the filenames out of the metadata for performance reasons this is the best we can do for now.

    When we move media to artifacts, this problem will be solved for us in a graceful way.

2. Fixes dataframes in `wandb.Table`
3. Fixes image format always being set to png for `seq_to_json`