### PR TITLE
Add tensorboard support (pytorch, tf2+)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
                   command: |
                       ulimit -n 1024
                       python3 -m tox -v -e py37
-                  no_output_timeout: 5m
+                  no_output_timeout: 10m
     final:
         docker:
             - image: python:3.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,4 +15,5 @@ include = '''
 | wandb/util/
 | wandb/server/
 | wandb/framework/gym/
+| wandb/framework/tensorboard/
 '''

--- a/tests/frameworks/test_keras.py
+++ b/tests/frameworks/test_keras.py
@@ -70,7 +70,8 @@ def test_basic_keras(dummy_model, dummy_data, wandb_init_run):
     dummy_model.fit(*dummy_data, epochs=2, batch_size=36, callbacks=[WandbCallback()])
     # wandb.run.summary.load()
     assert wandb.run._backend.history[0]["epoch"] == 0
-    assert wandb.run._backend.summary["loss"] > 0
+    # NOTE: backend mock doesnt copy history into summary (happens in internal process)
+    # assert wandb.run._backend.summary["loss"] > 0
     assert len(graph_json(wandb.run)["nodes"]) == 3
 
 

--- a/tests/wandb_tensorflow_test.py
+++ b/tests/wandb_tensorflow_test.py
@@ -6,7 +6,6 @@ import os
 import six
 import tensorflow as tf
 import wandb
-from wandb import tensorflow as wandb_tensorflow
 from wandb import wandb_sdk
 
 
@@ -39,7 +38,7 @@ def test_tf_log():
 
     history._set_callback(spy_cb)
 
-    wandb_tensorflow.log(SUMMARY_PB, history=history)
+    wandb.tensorboard.log(SUMMARY_PB, history=history)
     history.add({})  # Flush the previous row.
     assert len(summaries_logged) == 1
     summary = summaries_logged[0]
@@ -106,10 +105,10 @@ def test_hook():
         tf_summary.scalar("c1", c1)
         summary_op = tf_summary.merge_all()
 
-        hook = wandb_tensorflow.WandbHook(summary_op, history=history, steps_per_log=1)
+        hook = wandb.tensorflow.WandbHook(summary_op, history=history, steps_per_log=1)
         with MonitoredTrainingSession(hooks=[hook]) as sess:
             summary, acc = sess.run([summary_op, c1])
         history.add({})  # Flush the previous row.
 
-    assert wandb_tensorflow.tf_summary_to_dict(summary) == {"c1": 42.0}
+    assert wandb.tensorboard.tf_summary_to_dict(summary) == {"c1": 42.0}
     assert summaries_logged[0]["c1"] == 42.0

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -130,6 +130,7 @@ keras = _lazyloader.LazyLoader("wandb.keras", globals(), "wandb.framework.keras"
 sklearn = _lazyloader.LazyLoader("wandb.sklearn", globals(), "wandb.sklearn")
 tensorflow = _lazyloader.LazyLoader("wandb.tensorflow", globals(), "wandb.tensorflow")
 xgboost = _lazyloader.LazyLoader("wandb.xgboost", globals(), "wandb.framework.xgboost")
+tensorboard = _lazyloader.LazyLoader("wandb.tensorboard", globals(), "wandb.framework.tensorboard")
 gym = _lazyloader.LazyLoader("wandb.gym", globals(), "wandb.framework.gym")
 lightgbm = _lazyloader.LazyLoader(
     "wandb.lightgbm", globals(), "wandb.framework.lightgbm"

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -128,7 +128,7 @@ patched = {"tensorboard": [], "keras": [], "gym": []}
 
 keras = _lazyloader.LazyLoader("wandb.keras", globals(), "wandb.framework.keras")
 sklearn = _lazyloader.LazyLoader("wandb.sklearn", globals(), "wandb.sklearn")
-tensorflow = _lazyloader.LazyLoader("wandb.tensorflow", globals(), "wandb.tensorflow")
+tensorflow = _lazyloader.LazyLoader("wandb.tensorflow", globals(), "wandb.framework.tensorflow")
 xgboost = _lazyloader.LazyLoader("wandb.xgboost", globals(), "wandb.framework.xgboost")
 tensorboard = _lazyloader.LazyLoader("wandb.tensorboard", globals(), "wandb.framework.tensorboard")
 gym = _lazyloader.LazyLoader("wandb.gym", globals(), "wandb.framework.gym")

--- a/wandb/framework/tensorboard/__init__.py
+++ b/wandb/framework/tensorboard/__init__.py
@@ -1,0 +1,8 @@
+"""
+wandb framework tensorboard module.
+"""
+
+from wandb.framework.tensorboard.monkeypatch import patch
+
+__all__ = ['patch']
+

--- a/wandb/framework/tensorboard/__init__.py
+++ b/wandb/framework/tensorboard/__init__.py
@@ -3,6 +3,6 @@ wandb framework tensorboard module.
 """
 
 from .monkeypatch import patch
-from .log import log, tf_summary_to_dict
+from .log import log, tf_summary_to_dict, reset_state
 
 __all__ = ["patch"]

--- a/wandb/framework/tensorboard/__init__.py
+++ b/wandb/framework/tensorboard/__init__.py
@@ -4,5 +4,4 @@ wandb framework tensorboard module.
 
 from wandb.framework.tensorboard.monkeypatch import patch
 
-__all__ = ['patch']
-
+__all__ = ["patch"]

--- a/wandb/framework/tensorboard/__init__.py
+++ b/wandb/framework/tensorboard/__init__.py
@@ -2,6 +2,7 @@
 wandb framework tensorboard module.
 """
 
-from wandb.framework.tensorboard.monkeypatch import patch
+from .monkeypatch import patch
+from .log import log, tf_summary_to_dict
 
 __all__ = ["patch"]

--- a/wandb/framework/tensorboard/log.py
+++ b/wandb/framework/tensorboard/log.py
@@ -221,7 +221,7 @@ def log(tf_summary_str_or_pb, history=None, step=0, namespace="", **kwargs):
         if (
             RATE_LIMIT_SECONDS is None
             or timestamp - STEPS["global"]["last_log"]
-            >= RATE_LIMIT_SECONDS  # noqa: W503 E501
+            >= RATE_LIMIT_SECONDS
         ):
             history.add({}, **kwargs)
         STEPS["global"]["last_log"] = timestamp

--- a/wandb/framework/tensorboard/log.py
+++ b/wandb/framework/tensorboard/log.py
@@ -148,22 +148,23 @@ def tf_summary_to_dict(tf_summary_str_or_pb, namespace=""):  # noqa: C901
                     ),
                     repeat=False,
                 )
-        elif value.tag == "_hparams_/session_start_info":
-            if wandb.util.get_module("tensorboard.plugins.hparams"):
-                from tensorboard.plugins.hparams import plugin_data_pb2
-
-                plugin_data = plugin_data_pb2.HParamsPluginData()
-                plugin_data.ParseFromString(value.metadata.plugin_data.content)
-                for key, param in six.iteritems(plugin_data.session_start_info.hparams):
-                    if not wandb.run.config.get(key):
-                        wandb.run.config[key] = (
-                            param.number_value or param.string_value or param.bool_value
-                        )
-            else:
-                wandb.termerror(
-                    "Received hparams tf.summary, but could not import "
-                    "the hparams plugin from tensorboard"
-                )
+        # TODO(jhr): figure out how to share this between userspace and internal process or dont
+        # elif value.tag == "_hparams_/session_start_info":
+        #     if wandb.util.get_module("tensorboard.plugins.hparams"):
+        #         from tensorboard.plugins.hparams import plugin_data_pb2
+        #
+        #         plugin_data = plugin_data_pb2.HParamsPluginData()        #
+        #         plugin_data.ParseFromString(value.metadata.plugin_data.content)
+        #         for key, param in six.iteritems(plugin_data.session_start_info.hparams):
+        #             if not wandb.run.config.get(key):
+        #                 wandb.run.config[key] = (
+        #                     param.number_value or param.string_value or param.bool_value
+        #                 )
+        #     else:
+        #         wandb.termerror(
+        #             "Received hparams tf.summary, but could not import "
+        #             "the hparams plugin from tensorboard"
+        #         )
     return values
 
 

--- a/wandb/framework/tensorboard/log.py
+++ b/wandb/framework/tensorboard/log.py
@@ -220,8 +220,7 @@ def log(tf_summary_str_or_pb, history=None, step=0, namespace="", **kwargs):
         # Only commit our data if we're below the rate limit or don't have one
         if (
             RATE_LIMIT_SECONDS is None
-            or timestamp - STEPS["global"]["last_log"]
-            >= RATE_LIMIT_SECONDS
+            or timestamp - STEPS["global"]["last_log"] >= RATE_LIMIT_SECONDS
         ):
             history.add({}, **kwargs)
         STEPS["global"]["last_log"] = timestamp

--- a/wandb/framework/tensorboard/log.py
+++ b/wandb/framework/tensorboard/log.py
@@ -220,7 +220,8 @@ def log(tf_summary_str_or_pb, history=None, step=0, namespace="", **kwargs):
         # Only commit our data if we're below the rate limit or don't have one
         if (
             RATE_LIMIT_SECONDS is None
-            or timestamp - STEPS["global"]["last_log"] >= RATE_LIMIT_SECONDS  # noqa: W503 E501
+            or timestamp - STEPS["global"]["last_log"]
+            >= RATE_LIMIT_SECONDS  # noqa: W503 E501
         ):
             history.add({}, **kwargs)
         STEPS["global"]["last_log"] = timestamp

--- a/wandb/framework/tensorboard/monkeypatch.py
+++ b/wandb/framework/tensorboard/monkeypatch.py
@@ -30,7 +30,7 @@ def patch(save=None, tensorboardX=None, pytorch=None):
             writer=tb_writer, module=TENSORBOARD_PYTORCH_MODULE, save=save
         )
     else:
-        raise ValueError("Unsupported tensorboard configuration")
+        wandb.termerror("Unsupported tensorboard configuration")
 
 
 def _patch_tensorflow2(writer, module, save=None):
@@ -67,5 +67,6 @@ def _patch_nontensorflow(writer, module, save=None):
 
 def _notify_tensorboard_logdir(logdir, save=None):
     if REMOTE_FILE_TOKEN in logdir:
-        raise wandb.Error("Can not handle tensorboard_sync remote files: %s" % logdir)
+        wandb.termerror("Can not handle tensorboard_sync remote files: %s" % logdir)
+        return
     wandb.run._tensorboard_callback(logdir, save=save)

--- a/wandb/framework/tensorboard/monkeypatch.py
+++ b/wandb/framework/tensorboard/monkeypatch.py
@@ -2,6 +2,9 @@
 monkeypatch: patch code to add tensorboard hooks
 """
 
+import os
+import sys
+
 import wandb
 
 
@@ -15,6 +18,7 @@ def patch(save=None, tensorboardX=None, pytorch=None):
             "Tensorboard already patched, remove sync_tensorboard=True from wandb.init or only call wandb.tensorboard.patch once."
         )
 
+    wandb.util.get_module("tensorboard", required="Please install tensorboard package")
     c_writer = wandb.util.get_module(TENSORBOARD_C_MODULE)
     tb_writer = wandb.util.get_module(TENSORBOARD_PYTORCH_MODULE)
 

--- a/wandb/framework/tensorboard/monkeypatch.py
+++ b/wandb/framework/tensorboard/monkeypatch.py
@@ -10,6 +10,7 @@ import wandb
 
 TENSORBOARD_C_MODULE = "tensorflow.python.ops.gen_summary_ops"
 TENSORBOARD_PYTORCH_MODULE = "tensorboard.summary.writer.event_file_writer"
+REMOTE_FILE_TOKEN = "://"
 
 
 def patch(save=None, tensorboardX=None, pytorch=None):
@@ -65,4 +66,6 @@ def _patch_nontensorflow(writer, module, save=None):
 
 
 def _notify_tensorboard_logdir(logdir, save=None):
+    if REMOTE_FILE_TOKEN in logdir:
+        raise wandb.Error("Can not handle tensorboard_sync remote files: %s" % logdir)
     wandb.run._tensorboard_callback(logdir, save=save)

--- a/wandb/framework/tensorboard/monkeypatch.py
+++ b/wandb/framework/tensorboard/monkeypatch.py
@@ -1,0 +1,61 @@
+"""
+monkeypatch: patch code to add tensorboard hooks
+"""
+
+import wandb
+
+
+TENSORBOARD_C_MODULE = "tensorflow.python.ops.gen_summary_ops"
+TENSORBOARD_PYTORCH_MODULE = "tensorboard.summary.writer.event_file_writer"
+
+
+def patch(save=None, tensorboardX=None, pytorch=None):
+    if len(wandb.patched["tensorboard"]) > 0:
+        raise ValueError(
+            "Tensorboard already patched, remove sync_tensorboard=True from wandb.init or only call wandb.tensorboard.patch once.")
+
+    c_writer = wandb.util.get_module(TENSORBOARD_C_MODULE)
+    tb_writer = wandb.util.get_module(TENSORBOARD_PYTORCH_MODULE)
+
+    if c_writer:
+        _patch_tensorflow2(writer=c_writer, module=TENSORBOARD_C_MODULE, save=save)
+    elif tb_writer:
+        _patch_nontensorflow(writer=tb_writer, module=TENSORBOARD_PYTORCH_MODULE, save=save)
+    else:
+        raise ValueError("Unsupported tensorboard configuration")
+
+
+def _patch_tensorflow2(writer, module, save=None):
+    # This configures TensorFlow 2 style Tensorboard logging
+    old_csfw_func = writer.create_summary_file_writer
+
+    def new_csfw_func(*args, **kwargs):
+        logdir = kwargs['logdir'].numpy().decode("utf8") if hasattr(
+            kwargs['logdir'], 'numpy') else kwargs['logdir']
+        _notify_tensorboard_logdir(logdir, save=save)
+        return old_csfw_func(*args, **kwargs)
+
+    writer.orig_create_summary_file_writer = old_csfw_func
+    writer.create_summary_file_writer = new_csfw_func
+    wandb.patched["tensorboard"].append(
+        [module, "create_summary_file_writer"])
+
+
+def _patch_nontensorflow(writer, module, save=None):
+    # This configures non-TensorFlow Tensorboard logging
+    old_efw_class = writer.EventFileWriter
+
+    class TBXEventFileWriter(old_efw_class):
+        def __init__(self, logdir, *args, **kwargs):
+            _notify_tensorboard_logdir(logdir, save=save)
+            super(TBXEventFileWriter, self).__init__(logdir, *args, **kwargs)
+
+    writer.orig_EventFileWriter = old_efw_class
+    writer.EventFileWriter = TBXEventFileWriter
+    wandb.patched["tensorboard"].append(
+        [module, "EventFileWriter"])
+
+
+def _notify_tensorboard_logdir(logdir, save=None):
+    wandb.run._tensorboard_callback(logdir, save=save)
+

--- a/wandb/framework/tensorflow/__init__.py
+++ b/wandb/framework/tensorflow/__init__.py
@@ -4,4 +4,3 @@ api.
 """
 
 from .estimator_hook import WandbHook  # noqa: F401
-from .log import log, tf_summary_to_dict  # noqa: F401

--- a/wandb/framework/tensorflow/estimator_hook.py
+++ b/wandb/framework/tensorflow/estimator_hook.py
@@ -1,6 +1,5 @@
 import tensorflow as tf
-
-from .log import log
+import wandb
 
 
 if hasattr(tf.estimator, "SessionRunHook"):
@@ -43,6 +42,6 @@ class WandbHook(SessionRunHook):
         print(run_values)
         step = run_values.results["global_step"]
         if step % self._steps_per_log == 0:
-            log(
+            wandb.tensorboard.log(
                 run_values.results["summary"], history=self._history, step=step,
             )

--- a/wandb/framework/tensorflow/estimator_hook.py
+++ b/wandb/framework/tensorflow/estimator_hook.py
@@ -39,7 +39,6 @@ class WandbHook(SessionRunHook):
         )
 
     def after_run(self, run_context, run_values):
-        print(run_values)
         step = run_values.results["global_step"]
         if step % self._steps_per_log == 0:
             wandb.tensorboard.log(

--- a/wandb/interface/interface.py
+++ b/wandb/interface/interface.py
@@ -88,6 +88,13 @@ class BackendSender(object):
         rec.output.CopyFrom(outdata)
         self._queue_process(rec)
 
+    def send_tbdata(self, log_dir, save):
+        tbdata = wandb_internal_pb2.TBData()
+        tbdata.log_dir = log_dir
+        tbdata.save = save
+        rec = wandb_internal_pb2.Record(tbdata=tbdata)
+        self._queue_process(rec)
+
     def _send_history(self, history):
         rec = self._make_record(history=history)
         self._queue_process(rec)

--- a/wandb/internal/sender.py
+++ b/wandb/internal/sender.py
@@ -181,7 +181,7 @@ class SendManager(object):
         self._fs.start()
         self._pusher = FilePusher(self._api)
         self._dir_watcher = DirWatcher(self._settings, self._api, self._pusher)
-        self._tb_watcher = tb_watcher.TBWatcher(self._settings)
+        self._tb_watcher = tb_watcher.TBWatcher(self._settings, sender=self)
         self._run_id = run.run_id
         if self._run_meta:
             self._run_meta.write()
@@ -293,6 +293,8 @@ class SendManager(object):
         )
 
     def finish(self):
+        if self._tb_watcher:
+            self._tb_watcher.finish()
         if self._dir_watcher:
             self._dir_watcher.finish()
         if self._pusher:

--- a/wandb/internal/sender.py
+++ b/wandb/internal/sender.py
@@ -109,6 +109,11 @@ class SendManager(object):
         run_dir = self._settings.files_dir
         logger.info("scan: %s", run_dir)
 
+        # shutdown tensorboard workers so we get all metrics flushed
+        if self._tb_watcher:
+            self._tb_watcher.finish()
+            self._tb_watcher = None
+
         for dirpath, _, filenames in os.walk(run_dir):
             for fname in filenames:
                 file_path = os.path.join(dirpath, fname)

--- a/wandb/internal/sender.py
+++ b/wandb/internal/sender.py
@@ -89,6 +89,9 @@ class SendManager(object):
                     for k2, v2 in v.items():
                         dictionary[k + "." + k2] = v2
 
+    def handle_tbdata(self, data):
+        pass
+
     def handle_exit(self, data):
         exit = data.exit
         self._exit_code = exit.exit_code

--- a/wandb/internal/sender.py
+++ b/wandb/internal/sender.py
@@ -188,13 +188,16 @@ class SendManager(object):
         sentry_set_scope("internal", run.entity, run.project)
         logger.info("run started: %s", self._run_id)
 
+    def _save_history(self, history_dict):
+        if self._fs:
+            # print("\n\nABOUT TO SAVE:\n", history_dict, "\n\n")
+            self._fs.push("wandb-history.jsonl", json.dumps(history_dict))
+            # print("got", x)
+
     def handle_history(self, data):
         history = data.history
         history_dict = _dict_from_proto_list(history.item)
-        if self._fs:
-            # print("about to send", d)
-            self._fs.push("wandb-history.jsonl", json.dumps(history_dict))
-            # print("got", x)
+        self._save_history(history_dict)
 
     def handle_summary(self, data):
         summary = data.summary

--- a/wandb/internal/tb_watcher.py
+++ b/wandb/internal/tb_watcher.py
@@ -96,6 +96,7 @@ class TBDirWatcher(object):
         self._queue = queue
         self._file_version = None
         self._namespace = namespace
+        self._logdir = logdir
 
     def start(self):
         self._thread.start()
@@ -147,6 +148,7 @@ class TBDirWatcher(object):
                 time.sleep(1)
 
     def process_event(self, event):
+        # print("\nEVENT:::", self._logdir, self._namespace, event, "\n")
         if self._first_event_timestamp is None:
             self._first_event_timestamp = event.wall_time
 

--- a/wandb/internal/tb_watcher.py
+++ b/wandb/internal/tb_watcher.py
@@ -10,6 +10,7 @@ import time
 import six
 from six.moves import queue
 import wandb
+from wandb import data_types
 from wandb import util
 from wandb.util import json_dumps_safer_history
 
@@ -255,6 +256,11 @@ class TBEventConsumer(object):
         data = {}
         for k, v in six.iteritems(row):
             if v is None:
+                continue
+            if isinstance(v, data_types.Histogram):
+                v = v.to_json()
+            elif isinstance(v, data_types.WBValue):
+                # TODO(jhr): support more wandb data types
                 continue
             data[k] = json.loads(json_dumps_safer_history(v))
         self._tbwatcher._sender._save_history(data)

--- a/wandb/internal/tb_watcher.py
+++ b/wandb/internal/tb_watcher.py
@@ -2,11 +2,122 @@
 tensor b watcher.
 """
 
+import os
+import threading
+import time
+
+import six
+
 
 class TBWatcher(object):
-    def __init__(self, settings):
-        pass
+    def __init__(self, settings, sender=None):
+        self._logdirs = {}
+        self._settings = settings
+        self._sender = sender
 
-    def add(self, log_dir, save):
-        pass
-        # print("GOT", log_dir, save)
+    def _calculate_namespace(self, logdir):
+        dirs = list(self._logdirs) + [logdir]
+        rootdir = os.path.dirname(os.path.commonprefix(dirs))
+        if os.path.isfile(logdir):
+            filename = os.path.basename(logdir)
+        else:
+            filename = ""
+        # Tensorboard loads all tfevents files in a directory and prepends
+        # their values with the path.  Passing namespace to log allows us
+        # to nest the values in wandb
+        namespace = logdir.replace(filename, "").replace(rootdir, "").strip(os.sep)
+        # TODO: revisit this heuristic, it exists because we don't know the
+        # root log directory until more than one tfevents file is written to
+        if len(dirs) == 1 and namespace not in ["train", "validation"]:
+            namespace = None
+        return namespace
+
+    def add(self, logdir, save):
+        if logdir in self._logdirs:
+            return
+        namespace = self._calculate_namespace(logdir)
+
+        tbdir_watcher = TBDirWatcher(self, logdir, save, namespace)
+        self._logdirs[logdir] = tbdir_watcher
+        tbdir_watcher.start()
+
+    def finish(self):
+        for tbdirwatcher in six.itervalues(self._logdirs):
+            tbdirwatcher.finish()
+
+
+class TBDirWatcher(object):
+    from tensorboard.backend.event_processing import directory_watcher  # type: ignore
+    from tensorboard.backend.event_processing import event_file_loader  # type: ignore
+    from tensorboard.compat import tf as tf_compat  # type: ignore
+
+    def __init__(self, tbwatcher, logdir, save, namespace):
+        self._tbwatcher = tbwatcher
+        self._generator = self.directory_watcher.DirectoryWatcher(
+            logdir, self._loader(save, namespace), self._is_new_tensorflow_events_file
+        )
+        self._thread = threading.Thread(target=self._thread_body)
+        self._first_event_timestamp = None
+        self._shutdown = None
+
+    def start(self):
+        self._thread.start()
+
+    def _is_new_tensorflow_events_file(self, path):
+        """Checks if a path has been modified since launch and contains tfevents"""
+        if not path:
+            raise ValueError("Path must be a nonempty string")
+        path = self.tf_compat.compat.as_str_any(path)
+        is_mod_after_start = (
+            os.stat(path).st_mtime >= self._tbwatcher._settings._start_time
+        )
+        return "tfevents" in os.path.basename(path) and is_mod_after_start
+
+    def _loader(self, save=True, namespace=None):
+        """Incredibly hacky class generator to optionally save / prefix tfevent files"""
+        _loader_sender = self._tbwatcher._sender
+
+        class EventFileLoader(self.event_file_loader.EventFileLoader):
+            def __init__(self, file_path):
+                super(EventFileLoader, self).__init__(file_path)
+                if save:
+                    # TODO: save plugins?
+                    logdir = os.path.dirname(file_path)
+                    parts = list(os.path.split(logdir))
+                    if namespace and parts[-1] == namespace:
+                        parts.pop()
+                        logdir = os.path.join(*parts)
+                    # wandb.save(file_path, base_path=logdir)
+                    # TODO(jhr): deal with symlink file since out of files dir
+                    # TODO(jhr): need to figure out policy
+                    _loader_sender._save_file(file_path)
+
+        return EventFileLoader
+
+    def _thread_body(self):
+        """Check for new events every second"""
+        while True:
+            try:
+                for event in self._generator.Load():
+                    self.process_event(event)
+            except self.directory_watcher.DirectoryDeletedError:
+                break
+            if self._shutdown:
+                break
+            else:
+                time.sleep(1)
+
+    def process_event(self, event):
+        if self._first_event_timestamp is None:
+            self._first_event_timestamp = event.wall_time
+
+        if event.HasField("file_version"):
+            self.file_version = event.file_version
+
+        if event.HasField("summary"):
+            # self.queue.put(Event(event, self.namespace))
+            pass
+
+    def finish(self):
+        self._shutdown = True
+        self._thread.join()

--- a/wandb/internal/tb_watcher.py
+++ b/wandb/internal/tb_watcher.py
@@ -1,0 +1,12 @@
+"""
+tensor b watcher.
+"""
+
+
+class TBWatcher(object):
+    def __init__(self, settings):
+        pass
+
+    def add(self, log_dir, save):
+        pass
+        # print("GOT", log_dir, save)

--- a/wandb/internal/tb_watcher.py
+++ b/wandb/internal/tb_watcher.py
@@ -105,10 +105,13 @@ class TBDirWatcher(object):
         if not path:
             raise ValueError("Path must be a nonempty string")
         path = self.tf_compat.compat.as_str_any(path)
-        is_mod_after_start = (
-            os.stat(path).st_mtime >= self._tbwatcher._settings._start_time
+        base = os.path.basename(path)
+        start_time = self._tbwatcher._settings._start_time
+        return (
+            "tfevents" in base
+            and os.stat(path).st_mtime >= start_time  # noqa: W503
+            and not base.endswith(".profile-empty")  # noqa: W503
         )
-        return "tfevents" in os.path.basename(path) and is_mod_after_start
 
     def _loader(self, save=True, namespace=None):
         """Incredibly hacky class generator to optionally save / prefix tfevent files"""

--- a/wandb/internal/tb_watcher.py
+++ b/wandb/internal/tb_watcher.py
@@ -90,13 +90,16 @@ class TBWatcher(object):
 class TBDirWatcher(object):
     def __init__(self, tbwatcher, logdir, save, namespace, queue):
         self.directory_watcher = util.get_module(
-                "tensorboard.backend.event_processing.directory_watcher",
-                required="Please install tensorboard package")
+            "tensorboard.backend.event_processing.directory_watcher",
+            required="Please install tensorboard package",
+        )
         self.event_file_loader = util.get_module(
-                "tensorboard.backend.event_processing.event_file_loader",
-                required="Please install tensorboard package")
-        self.tf_compat = util.get_module("tensorboard.compat",
-                required="Please install tensorboard package")
+            "tensorboard.backend.event_processing.event_file_loader",
+            required="Please install tensorboard package",
+        )
+        self.tf_compat = util.get_module(
+            "tensorboard.compat", required="Please install tensorboard package"
+        )
         self._tbwatcher = tbwatcher
         self._generator = self.directory_watcher.DirectoryWatcher(
             logdir, self._loader(save, namespace), self._is_new_tensorflow_events_file

--- a/wandb/internal/tb_watcher.py
+++ b/wandb/internal/tb_watcher.py
@@ -212,7 +212,7 @@ class TBEventConsumer(object):
                     self._save_row(item)
 
     def _handle_event(self, event, history=None):
-        wandb.tensorflow.log(
+        wandb.tensorboard.log(
             event.event,
             step=event.event.step,
             namespace=event.namespace,
@@ -225,7 +225,6 @@ class TBEventConsumer(object):
             if v is None:
                 continue
             data[k] = json.loads(json_dumps_safer_history(v))
-        # print("\n\nABOUT TO SAVE:\n", data, "\n\n")
         self._tbwatcher._sender._save_history(data)
 
 

--- a/wandb/proto/wandb_internal.proto
+++ b/wandb/proto/wandb_internal.proto
@@ -20,6 +20,7 @@ message Record {
     RunData         run = 17;
     ExitData        exit = 18;
     StatusData      status = 19;
+    TBData          tbdata = 20;
   }
   Control       control = 16;
 }
@@ -206,6 +207,11 @@ message ExitData {
 
 
 message StatusData {
+}
+
+message TBData {
+  string log_dir = 1;
+  bool   save = 2;
 }
 
 /*

--- a/wandb/proto/wandb_internal_pb2.py
+++ b/wandb/proto/wandb_internal_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='wandb_internal',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=b'\n wandb/proto/wandb_internal.proto\x12\x0ewandb_internal\x1a\x1fgoogle/protobuf/timestamp.proto\"\x8d\x04\n\x06Record\x12\x0b\n\x03num\x18\x01 \x01(\x03\x12.\n\x07history\x18\x02 \x01(\x0b\x32\x1b.wandb_internal.HistoryDataH\x00\x12.\n\x07summary\x18\x03 \x01(\x0b\x32\x1b.wandb_internal.SummaryDataH\x00\x12,\n\x06output\x18\x04 \x01(\x0b\x32\x1a.wandb_internal.OutputDataH\x00\x12,\n\x06\x63onfig\x18\x05 \x01(\x0b\x32\x1a.wandb_internal.ConfigDataH\x00\x12*\n\x05\x66iles\x18\x06 \x01(\x0b\x32\x19.wandb_internal.FilesDataH\x00\x12*\n\x05stats\x18\x07 \x01(\x0b\x32\x19.wandb_internal.StatsDataH\x00\x12\x30\n\x08\x61rtifact\x18\x08 \x01(\x0b\x32\x1c.wandb_internal.ArtifactDataH\x00\x12&\n\x03run\x18\x11 \x01(\x0b\x32\x17.wandb_internal.RunDataH\x00\x12(\n\x04\x65xit\x18\x12 \x01(\x0b\x32\x18.wandb_internal.ExitDataH\x00\x12,\n\x06status\x18\x13 \x01(\x0b\x32\x1a.wandb_internal.StatusDataH\x00\x12(\n\x07\x63ontrol\x18\x10 \x01(\x0b\x32\x17.wandb_internal.ControlB\x06\n\x04\x64\x61ta\"*\n\x07\x43ontrol\x12\x10\n\x08req_resp\x18\x01 \x01(\x08\x12\r\n\x05local\x18\x02 \x01(\x08\"\x80\x03\n\x07RunData\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x0e\n\x06\x65ntity\x18\x02 \x01(\t\x12\x0f\n\x07project\x18\x03 \x01(\t\x12*\n\x06\x63onfig\x18\x04 \x01(\x0b\x32\x1a.wandb_internal.ConfigData\x12,\n\x07summary\x18\x05 \x01(\x0b\x32\x1b.wandb_internal.SummaryData\x12\x11\n\trun_group\x18\x06 \x01(\t\x12\x10\n\x08job_type\x18\x07 \x01(\t\x12\x14\n\x0c\x64isplay_name\x18\x08 \x01(\t\x12\r\n\x05notes\x18\t \x01(\t\x12\x0c\n\x04tags\x18\n \x03(\t\x12.\n\x08settings\x18\x0b \x01(\x0b\x32\x1c.wandb_internal.SettingsData\x12\x10\n\x08sweep_id\x18\x0c \x01(\t\x12\x0c\n\x04host\x18\r \x01(\t\x12\x12\n\nstorage_id\x18\x10 \x01(\t\x12.\n\nstart_time\x18\x11 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\":\n\x0cSettingsData\x12*\n\x04item\x18\x01 \x03(\x0b\x32\x1c.wandb_internal.SettingsItem\"/\n\x0cSettingsItem\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x12\n\nvalue_json\x18\x10 \x01(\t\"8\n\x0bHistoryData\x12)\n\x04item\x18\x01 \x03(\x0b\x32\x1b.wandb_internal.HistoryItem\"B\n\x0bHistoryItem\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x12\n\nnested_key\x18\x02 \x03(\t\x12\x12\n\nvalue_json\x18\x10 \x01(\t\"\xab\x01\n\nOutputData\x12:\n\x0boutput_type\x18\x01 \x01(\x0e\x32%.wandb_internal.OutputData.OutputType\x12-\n\ttimestamp\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x0c\n\x04line\x18\x03 \x01(\t\"$\n\nOutputType\x12\n\n\x06STDERR\x10\x00\x12\n\n\x06STDOUT\x10\x01\"d\n\nConfigData\x12*\n\x06update\x18\x01 \x03(\x0b\x32\x1a.wandb_internal.ConfigItem\x12*\n\x06remove\x18\x02 \x03(\x0b\x32\x1a.wandb_internal.ConfigItem\"A\n\nConfigItem\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x12\n\nnested_key\x18\x02 \x03(\t\x12\x12\n\nvalue_json\x18\x10 \x01(\t\"g\n\x0bSummaryData\x12+\n\x06update\x18\x01 \x03(\x0b\x32\x1b.wandb_internal.SummaryItem\x12+\n\x06remove\x18\x02 \x03(\x0b\x32\x1b.wandb_internal.SummaryItem\"B\n\x0bSummaryItem\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x12\n\nnested_key\x18\x02 \x03(\t\x12\x12\n\nvalue_json\x18\x10 \x01(\t\"5\n\tFilesData\x12(\n\x05\x66iles\x18\x01 \x03(\x0b\x32\x19.wandb_internal.FilesItem\"\x90\x01\n\tFilesItem\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x34\n\x06policy\x18\x02 \x01(\x0e\x32$.wandb_internal.FilesItem.PolicyType\x12\x15\n\rexternal_path\x18\x10 \x01(\t\"(\n\nPolicyType\x12\x07\n\x03NOW\x10\x00\x12\x07\n\x03\x45ND\x10\x01\x12\x08\n\x04LIVE\x10\x02\"\xb5\x01\n\tStatsData\x12\x37\n\nstats_type\x18\x01 \x01(\x0e\x32#.wandb_internal.StatsData.StatsType\x12-\n\ttimestamp\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\'\n\x04item\x18\x03 \x03(\x0b\x32\x19.wandb_internal.StatsItem\"\x17\n\tStatsType\x12\n\n\x06SYSTEM\x10\x00\",\n\tStatsItem\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x12\n\nvalue_json\x18\x10 \x01(\t\"\x87\x02\n\x0c\x41rtifactData\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x0f\n\x07project\x18\x02 \x01(\t\x12\x0e\n\x06\x65ntity\x18\x03 \x01(\t\x12\x0c\n\x04type\x18\x04 \x01(\t\x12\x0c\n\x04name\x18\x05 \x01(\t\x12\x0e\n\x06\x64igest\x18\x06 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x07 \x01(\t\x12\x10\n\x08metadata\x18\x08 \x01(\t\x12\x14\n\x0cuser_created\x18\t \x01(\x08\x12\x18\n\x10use_after_commit\x18\n \x01(\x08\x12\x0f\n\x07\x61liases\x18\x0b \x03(\t\x12\x32\n\x08manifest\x18\x0c \x01(\x0b\x32 .wandb_internal.ArtifactManifest\"\xbc\x01\n\x10\x41rtifactManifest\x12\x0f\n\x07version\x18\x01 \x01(\x05\x12\x16\n\x0estorage_policy\x18\x02 \x01(\t\x12\x46\n\x15storage_policy_config\x18\x03 \x03(\x0b\x32\'.wandb_internal.StoragePolicyConfigItem\x12\x37\n\x08\x63ontents\x18\x04 \x03(\x0b\x32%.wandb_internal.ArtifactManifestEntry\"\xa0\x01\n\x15\x41rtifactManifestEntry\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0e\n\x06\x64igest\x18\x02 \x01(\t\x12\x0b\n\x03ref\x18\x03 \x01(\t\x12\x0c\n\x04size\x18\x04 \x01(\x03\x12\x10\n\x08mimetype\x18\x05 \x01(\t\x12\x12\n\nlocal_path\x18\x06 \x01(\t\x12(\n\x05\x65xtra\x18\x10 \x03(\x0b\x32\x19.wandb_internal.ExtraItem\",\n\tExtraItem\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x12\n\nvalue_json\x18\x02 \x01(\t\":\n\x17StoragePolicyConfigItem\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x12\n\nvalue_json\x18\x02 \x01(\t\"\x1d\n\x08\x45xitData\x12\x11\n\texit_code\x18\x01 \x01(\x05\"\x0c\n\nStatusData\"7\n\x0fRunUpdateResult\x12$\n\x03run\x18\x01 \x01(\x0b\x32\x17.wandb_internal.RunData\"\x0f\n\rRunExitResult\"\x0b\n\tLogResult\"\x0e\n\x0cStatusResult\"\x0f\n\rSummaryResult\"\x0e\n\x0cOutputResult\"\x0e\n\x0c\x43onfigResult\"\x92\x03\n\x0cResultRecord\x12\x35\n\nrun_result\x18\x11 \x01(\x0b\x32\x1f.wandb_internal.RunUpdateResultH\x00\x12\x34\n\x0b\x65xit_result\x18\x12 \x01(\x0b\x32\x1d.wandb_internal.RunExitResultH\x00\x12\x35\n\rstatus_result\x18\x13 \x01(\x0b\x32\x1c.wandb_internal.StatusResultH\x00\x12/\n\nlog_result\x18\x14 \x01(\x0b\x32\x19.wandb_internal.LogResultH\x00\x12\x37\n\x0esummary_result\x18\x15 \x01(\x0b\x32\x1d.wandb_internal.SummaryResultH\x00\x12\x35\n\routput_result\x18\x16 \x01(\x0b\x32\x1c.wandb_internal.OutputResultH\x00\x12\x35\n\rconfig_result\x18\x17 \x01(\x0b\x32\x1c.wandb_internal.ConfigResultH\x00\x42\x06\n\x04\x64\x61tab\x06proto3'
+  serialized_pb=b'\n wandb/proto/wandb_internal.proto\x12\x0ewandb_internal\x1a\x1fgoogle/protobuf/timestamp.proto\"\xb7\x04\n\x06Record\x12\x0b\n\x03num\x18\x01 \x01(\x03\x12.\n\x07history\x18\x02 \x01(\x0b\x32\x1b.wandb_internal.HistoryDataH\x00\x12.\n\x07summary\x18\x03 \x01(\x0b\x32\x1b.wandb_internal.SummaryDataH\x00\x12,\n\x06output\x18\x04 \x01(\x0b\x32\x1a.wandb_internal.OutputDataH\x00\x12,\n\x06\x63onfig\x18\x05 \x01(\x0b\x32\x1a.wandb_internal.ConfigDataH\x00\x12*\n\x05\x66iles\x18\x06 \x01(\x0b\x32\x19.wandb_internal.FilesDataH\x00\x12*\n\x05stats\x18\x07 \x01(\x0b\x32\x19.wandb_internal.StatsDataH\x00\x12\x30\n\x08\x61rtifact\x18\x08 \x01(\x0b\x32\x1c.wandb_internal.ArtifactDataH\x00\x12&\n\x03run\x18\x11 \x01(\x0b\x32\x17.wandb_internal.RunDataH\x00\x12(\n\x04\x65xit\x18\x12 \x01(\x0b\x32\x18.wandb_internal.ExitDataH\x00\x12,\n\x06status\x18\x13 \x01(\x0b\x32\x1a.wandb_internal.StatusDataH\x00\x12(\n\x06tbdata\x18\x14 \x01(\x0b\x32\x16.wandb_internal.TBDataH\x00\x12(\n\x07\x63ontrol\x18\x10 \x01(\x0b\x32\x17.wandb_internal.ControlB\x06\n\x04\x64\x61ta\"*\n\x07\x43ontrol\x12\x10\n\x08req_resp\x18\x01 \x01(\x08\x12\r\n\x05local\x18\x02 \x01(\x08\"\x80\x03\n\x07RunData\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x0e\n\x06\x65ntity\x18\x02 \x01(\t\x12\x0f\n\x07project\x18\x03 \x01(\t\x12*\n\x06\x63onfig\x18\x04 \x01(\x0b\x32\x1a.wandb_internal.ConfigData\x12,\n\x07summary\x18\x05 \x01(\x0b\x32\x1b.wandb_internal.SummaryData\x12\x11\n\trun_group\x18\x06 \x01(\t\x12\x10\n\x08job_type\x18\x07 \x01(\t\x12\x14\n\x0c\x64isplay_name\x18\x08 \x01(\t\x12\r\n\x05notes\x18\t \x01(\t\x12\x0c\n\x04tags\x18\n \x03(\t\x12.\n\x08settings\x18\x0b \x01(\x0b\x32\x1c.wandb_internal.SettingsData\x12\x10\n\x08sweep_id\x18\x0c \x01(\t\x12\x0c\n\x04host\x18\r \x01(\t\x12\x12\n\nstorage_id\x18\x10 \x01(\t\x12.\n\nstart_time\x18\x11 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\":\n\x0cSettingsData\x12*\n\x04item\x18\x01 \x03(\x0b\x32\x1c.wandb_internal.SettingsItem\"/\n\x0cSettingsItem\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x12\n\nvalue_json\x18\x10 \x01(\t\"8\n\x0bHistoryData\x12)\n\x04item\x18\x01 \x03(\x0b\x32\x1b.wandb_internal.HistoryItem\"B\n\x0bHistoryItem\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x12\n\nnested_key\x18\x02 \x03(\t\x12\x12\n\nvalue_json\x18\x10 \x01(\t\"\xab\x01\n\nOutputData\x12:\n\x0boutput_type\x18\x01 \x01(\x0e\x32%.wandb_internal.OutputData.OutputType\x12-\n\ttimestamp\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x0c\n\x04line\x18\x03 \x01(\t\"$\n\nOutputType\x12\n\n\x06STDERR\x10\x00\x12\n\n\x06STDOUT\x10\x01\"d\n\nConfigData\x12*\n\x06update\x18\x01 \x03(\x0b\x32\x1a.wandb_internal.ConfigItem\x12*\n\x06remove\x18\x02 \x03(\x0b\x32\x1a.wandb_internal.ConfigItem\"A\n\nConfigItem\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x12\n\nnested_key\x18\x02 \x03(\t\x12\x12\n\nvalue_json\x18\x10 \x01(\t\"g\n\x0bSummaryData\x12+\n\x06update\x18\x01 \x03(\x0b\x32\x1b.wandb_internal.SummaryItem\x12+\n\x06remove\x18\x02 \x03(\x0b\x32\x1b.wandb_internal.SummaryItem\"B\n\x0bSummaryItem\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x12\n\nnested_key\x18\x02 \x03(\t\x12\x12\n\nvalue_json\x18\x10 \x01(\t\"5\n\tFilesData\x12(\n\x05\x66iles\x18\x01 \x03(\x0b\x32\x19.wandb_internal.FilesItem\"\x90\x01\n\tFilesItem\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x34\n\x06policy\x18\x02 \x01(\x0e\x32$.wandb_internal.FilesItem.PolicyType\x12\x15\n\rexternal_path\x18\x10 \x01(\t\"(\n\nPolicyType\x12\x07\n\x03NOW\x10\x00\x12\x07\n\x03\x45ND\x10\x01\x12\x08\n\x04LIVE\x10\x02\"\xb5\x01\n\tStatsData\x12\x37\n\nstats_type\x18\x01 \x01(\x0e\x32#.wandb_internal.StatsData.StatsType\x12-\n\ttimestamp\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\'\n\x04item\x18\x03 \x03(\x0b\x32\x19.wandb_internal.StatsItem\"\x17\n\tStatsType\x12\n\n\x06SYSTEM\x10\x00\",\n\tStatsItem\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x12\n\nvalue_json\x18\x10 \x01(\t\"\x87\x02\n\x0c\x41rtifactData\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x0f\n\x07project\x18\x02 \x01(\t\x12\x0e\n\x06\x65ntity\x18\x03 \x01(\t\x12\x0c\n\x04type\x18\x04 \x01(\t\x12\x0c\n\x04name\x18\x05 \x01(\t\x12\x0e\n\x06\x64igest\x18\x06 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x07 \x01(\t\x12\x10\n\x08metadata\x18\x08 \x01(\t\x12\x14\n\x0cuser_created\x18\t \x01(\x08\x12\x18\n\x10use_after_commit\x18\n \x01(\x08\x12\x0f\n\x07\x61liases\x18\x0b \x03(\t\x12\x32\n\x08manifest\x18\x0c \x01(\x0b\x32 .wandb_internal.ArtifactManifest\"\xbc\x01\n\x10\x41rtifactManifest\x12\x0f\n\x07version\x18\x01 \x01(\x05\x12\x16\n\x0estorage_policy\x18\x02 \x01(\t\x12\x46\n\x15storage_policy_config\x18\x03 \x03(\x0b\x32\'.wandb_internal.StoragePolicyConfigItem\x12\x37\n\x08\x63ontents\x18\x04 \x03(\x0b\x32%.wandb_internal.ArtifactManifestEntry\"\xa0\x01\n\x15\x41rtifactManifestEntry\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0e\n\x06\x64igest\x18\x02 \x01(\t\x12\x0b\n\x03ref\x18\x03 \x01(\t\x12\x0c\n\x04size\x18\x04 \x01(\x03\x12\x10\n\x08mimetype\x18\x05 \x01(\t\x12\x12\n\nlocal_path\x18\x06 \x01(\t\x12(\n\x05\x65xtra\x18\x10 \x03(\x0b\x32\x19.wandb_internal.ExtraItem\",\n\tExtraItem\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x12\n\nvalue_json\x18\x02 \x01(\t\":\n\x17StoragePolicyConfigItem\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x12\n\nvalue_json\x18\x02 \x01(\t\"\x1d\n\x08\x45xitData\x12\x11\n\texit_code\x18\x01 \x01(\x05\"\x0c\n\nStatusData\"\'\n\x06TBData\x12\x0f\n\x07log_dir\x18\x01 \x01(\t\x12\x0c\n\x04save\x18\x02 \x01(\x08\"7\n\x0fRunUpdateResult\x12$\n\x03run\x18\x01 \x01(\x0b\x32\x17.wandb_internal.RunData\"\x0f\n\rRunExitResult\"\x0b\n\tLogResult\"\x0e\n\x0cStatusResult\"\x0f\n\rSummaryResult\"\x0e\n\x0cOutputResult\"\x0e\n\x0c\x43onfigResult\"\x92\x03\n\x0cResultRecord\x12\x35\n\nrun_result\x18\x11 \x01(\x0b\x32\x1f.wandb_internal.RunUpdateResultH\x00\x12\x34\n\x0b\x65xit_result\x18\x12 \x01(\x0b\x32\x1d.wandb_internal.RunExitResultH\x00\x12\x35\n\rstatus_result\x18\x13 \x01(\x0b\x32\x1c.wandb_internal.StatusResultH\x00\x12/\n\nlog_result\x18\x14 \x01(\x0b\x32\x19.wandb_internal.LogResultH\x00\x12\x37\n\x0esummary_result\x18\x15 \x01(\x0b\x32\x1d.wandb_internal.SummaryResultH\x00\x12\x35\n\routput_result\x18\x16 \x01(\x0b\x32\x1c.wandb_internal.OutputResultH\x00\x12\x35\n\rconfig_result\x18\x17 \x01(\x0b\x32\x1c.wandb_internal.ConfigResultH\x00\x42\x06\n\x04\x64\x61tab\x06proto3'
   ,
   dependencies=[google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,])
 
@@ -42,8 +42,8 @@ _OUTPUTDATA_OUTPUTTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=1415,
-  serialized_end=1451,
+  serialized_start=1457,
+  serialized_end=1493,
 )
 _sym_db.RegisterEnumDescriptor(_OUTPUTDATA_OUTPUTTYPE)
 
@@ -68,8 +68,8 @@ _FILESITEM_POLICYTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=1955,
-  serialized_end=1995,
+  serialized_start=1997,
+  serialized_end=2037,
 )
 _sym_db.RegisterEnumDescriptor(_FILESITEM_POLICYTYPE)
 
@@ -86,8 +86,8 @@ _STATSDATA_STATSTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=2156,
-  serialized_end=2179,
+  serialized_start=2198,
+  serialized_end=2221,
 )
 _sym_db.RegisterEnumDescriptor(_STATSDATA_STATSTYPE)
 
@@ -177,7 +177,14 @@ _RECORD = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='control', full_name='wandb_internal.Record.control', index=11,
+      name='tbdata', full_name='wandb_internal.Record.tbdata', index=11,
+      number=20, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='control', full_name='wandb_internal.Record.control', index=12,
       number=16, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -199,7 +206,7 @@ _RECORD = _descriptor.Descriptor(
       index=0, containing_type=None, fields=[]),
   ],
   serialized_start=86,
-  serialized_end=611,
+  serialized_end=653,
 )
 
 
@@ -236,8 +243,8 @@ _CONTROL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=613,
-  serialized_end=655,
+  serialized_start=655,
+  serialized_end=697,
 )
 
 
@@ -365,8 +372,8 @@ _RUNDATA = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=658,
-  serialized_end=1042,
+  serialized_start=700,
+  serialized_end=1084,
 )
 
 
@@ -396,8 +403,8 @@ _SETTINGSDATA = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1044,
-  serialized_end=1102,
+  serialized_start=1086,
+  serialized_end=1144,
 )
 
 
@@ -434,8 +441,8 @@ _SETTINGSITEM = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1104,
-  serialized_end=1151,
+  serialized_start=1146,
+  serialized_end=1193,
 )
 
 
@@ -465,8 +472,8 @@ _HISTORYDATA = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1153,
-  serialized_end=1209,
+  serialized_start=1195,
+  serialized_end=1251,
 )
 
 
@@ -510,8 +517,8 @@ _HISTORYITEM = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1211,
-  serialized_end=1277,
+  serialized_start=1253,
+  serialized_end=1319,
 )
 
 
@@ -556,8 +563,8 @@ _OUTPUTDATA = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1280,
-  serialized_end=1451,
+  serialized_start=1322,
+  serialized_end=1493,
 )
 
 
@@ -594,8 +601,8 @@ _CONFIGDATA = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1453,
-  serialized_end=1553,
+  serialized_start=1495,
+  serialized_end=1595,
 )
 
 
@@ -639,8 +646,8 @@ _CONFIGITEM = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1555,
-  serialized_end=1620,
+  serialized_start=1597,
+  serialized_end=1662,
 )
 
 
@@ -677,8 +684,8 @@ _SUMMARYDATA = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1622,
-  serialized_end=1725,
+  serialized_start=1664,
+  serialized_end=1767,
 )
 
 
@@ -722,8 +729,8 @@ _SUMMARYITEM = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1727,
-  serialized_end=1793,
+  serialized_start=1769,
+  serialized_end=1835,
 )
 
 
@@ -753,8 +760,8 @@ _FILESDATA = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1795,
-  serialized_end=1848,
+  serialized_start=1837,
+  serialized_end=1890,
 )
 
 
@@ -799,8 +806,8 @@ _FILESITEM = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1851,
-  serialized_end=1995,
+  serialized_start=1893,
+  serialized_end=2037,
 )
 
 
@@ -845,8 +852,8 @@ _STATSDATA = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1998,
-  serialized_end=2179,
+  serialized_start=2040,
+  serialized_end=2221,
 )
 
 
@@ -883,8 +890,8 @@ _STATSITEM = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2181,
-  serialized_end=2225,
+  serialized_start=2223,
+  serialized_end=2267,
 )
 
 
@@ -991,8 +998,8 @@ _ARTIFACTDATA = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2228,
-  serialized_end=2491,
+  serialized_start=2270,
+  serialized_end=2533,
 )
 
 
@@ -1043,8 +1050,8 @@ _ARTIFACTMANIFEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2494,
-  serialized_end=2682,
+  serialized_start=2536,
+  serialized_end=2724,
 )
 
 
@@ -1116,8 +1123,8 @@ _ARTIFACTMANIFESTENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2685,
-  serialized_end=2845,
+  serialized_start=2727,
+  serialized_end=2887,
 )
 
 
@@ -1154,8 +1161,8 @@ _EXTRAITEM = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2847,
-  serialized_end=2891,
+  serialized_start=2889,
+  serialized_end=2933,
 )
 
 
@@ -1192,8 +1199,8 @@ _STORAGEPOLICYCONFIGITEM = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2893,
-  serialized_end=2951,
+  serialized_start=2935,
+  serialized_end=2993,
 )
 
 
@@ -1223,8 +1230,8 @@ _EXITDATA = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2953,
-  serialized_end=2982,
+  serialized_start=2995,
+  serialized_end=3024,
 )
 
 
@@ -1247,8 +1254,46 @@ _STATUSDATA = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2984,
-  serialized_end=2996,
+  serialized_start=3026,
+  serialized_end=3038,
+)
+
+
+_TBDATA = _descriptor.Descriptor(
+  name='TBData',
+  full_name='wandb_internal.TBData',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='log_dir', full_name='wandb_internal.TBData.log_dir', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='save', full_name='wandb_internal.TBData.save', index=1,
+      number=2, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=3040,
+  serialized_end=3079,
 )
 
 
@@ -1278,8 +1323,8 @@ _RUNUPDATERESULT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2998,
-  serialized_end=3053,
+  serialized_start=3081,
+  serialized_end=3136,
 )
 
 
@@ -1302,8 +1347,8 @@ _RUNEXITRESULT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3055,
-  serialized_end=3070,
+  serialized_start=3138,
+  serialized_end=3153,
 )
 
 
@@ -1326,8 +1371,8 @@ _LOGRESULT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3072,
-  serialized_end=3083,
+  serialized_start=3155,
+  serialized_end=3166,
 )
 
 
@@ -1350,8 +1395,8 @@ _STATUSRESULT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3085,
-  serialized_end=3099,
+  serialized_start=3168,
+  serialized_end=3182,
 )
 
 
@@ -1374,8 +1419,8 @@ _SUMMARYRESULT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3101,
-  serialized_end=3116,
+  serialized_start=3184,
+  serialized_end=3199,
 )
 
 
@@ -1398,8 +1443,8 @@ _OUTPUTRESULT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3118,
-  serialized_end=3132,
+  serialized_start=3201,
+  serialized_end=3215,
 )
 
 
@@ -1422,8 +1467,8 @@ _CONFIGRESULT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3134,
-  serialized_end=3148,
+  serialized_start=3217,
+  serialized_end=3231,
 )
 
 
@@ -1498,8 +1543,8 @@ _RESULTRECORD = _descriptor.Descriptor(
       name='data', full_name='wandb_internal.ResultRecord.data',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=3151,
-  serialized_end=3553,
+  serialized_start=3234,
+  serialized_end=3636,
 )
 
 _RECORD.fields_by_name['history'].message_type = _HISTORYDATA
@@ -1512,6 +1557,7 @@ _RECORD.fields_by_name['artifact'].message_type = _ARTIFACTDATA
 _RECORD.fields_by_name['run'].message_type = _RUNDATA
 _RECORD.fields_by_name['exit'].message_type = _EXITDATA
 _RECORD.fields_by_name['status'].message_type = _STATUSDATA
+_RECORD.fields_by_name['tbdata'].message_type = _TBDATA
 _RECORD.fields_by_name['control'].message_type = _CONTROL
 _RECORD.oneofs_by_name['data'].fields.append(
   _RECORD.fields_by_name['history'])
@@ -1543,6 +1589,9 @@ _RECORD.fields_by_name['exit'].containing_oneof = _RECORD.oneofs_by_name['data']
 _RECORD.oneofs_by_name['data'].fields.append(
   _RECORD.fields_by_name['status'])
 _RECORD.fields_by_name['status'].containing_oneof = _RECORD.oneofs_by_name['data']
+_RECORD.oneofs_by_name['data'].fields.append(
+  _RECORD.fields_by_name['tbdata'])
+_RECORD.fields_by_name['tbdata'].containing_oneof = _RECORD.oneofs_by_name['data']
 _RUNDATA.fields_by_name['config'].message_type = _CONFIGDATA
 _RUNDATA.fields_by_name['summary'].message_type = _SUMMARYDATA
 _RUNDATA.fields_by_name['settings'].message_type = _SETTINGSDATA
@@ -1619,6 +1668,7 @@ DESCRIPTOR.message_types_by_name['ExtraItem'] = _EXTRAITEM
 DESCRIPTOR.message_types_by_name['StoragePolicyConfigItem'] = _STORAGEPOLICYCONFIGITEM
 DESCRIPTOR.message_types_by_name['ExitData'] = _EXITDATA
 DESCRIPTOR.message_types_by_name['StatusData'] = _STATUSDATA
+DESCRIPTOR.message_types_by_name['TBData'] = _TBDATA
 DESCRIPTOR.message_types_by_name['RunUpdateResult'] = _RUNUPDATERESULT
 DESCRIPTOR.message_types_by_name['RunExitResult'] = _RUNEXITRESULT
 DESCRIPTOR.message_types_by_name['LogResult'] = _LOGRESULT
@@ -1789,6 +1839,13 @@ StatusData = _reflection.GeneratedProtocolMessageType('StatusData', (_message.Me
   # @@protoc_insertion_point(class_scope:wandb_internal.StatusData)
   })
 _sym_db.RegisterMessage(StatusData)
+
+TBData = _reflection.GeneratedProtocolMessageType('TBData', (_message.Message,), {
+  'DESCRIPTOR' : _TBDATA,
+  '__module__' : 'wandb.proto.wandb_internal_pb2'
+  # @@protoc_insertion_point(class_scope:wandb_internal.TBData)
+  })
+_sym_db.RegisterMessage(TBData)
 
 RunUpdateResult = _reflection.GeneratedProtocolMessageType('RunUpdateResult', (_message.Message,), {
   'DESCRIPTOR' : _RUNUPDATERESULT,

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -94,8 +94,6 @@ class _WandbInit(object):
             "allow_val_change",
             "resume",
             "force",
-            "tensorboard",
-            "sync_tensorboard",
         )
         for key in unsupported:
             val = kwargs.pop(key, None)
@@ -107,6 +105,11 @@ class _WandbInit(object):
         monitor_gym = kwargs.pop("monitor_gym", None)
         if monitor_gym and len(wandb.patched["gym"]) == 0:
             wandb.gym.monitor()
+
+        tensorboard = kwargs.pop("tensorboard", None)
+        sync_tensorboard = kwargs.pop("sync_tensorboard", None)
+        if tensorboard or sync_tensorboard and len(wandb.patched["tensorboard"]) == 0:
+            wandb.tensorboard.patch()
 
         # prevent setting project, entity if in sweep
         # TODO(jhr): these should be locked elements in the future or at least

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -292,8 +292,13 @@ class RunManaged(Run):
         self.summary.update(row)
 
     def _console_callback(self, name, data):
-        logger.info("callback: %s, %s", name, data)
+        logger.info("console callback: %s, %s", name, data)
         self._backend.interface.send_output(name, data)
+
+    def _tensorboard_callback(self, logdir, save=None):
+        logger.info("tensorboard callback: %s, %s", logdir, save)
+        save = True if save is None else save
+        #self._backend.interface.send_output(name, data)
 
     def _set_library(self, library):
         self._wl = library

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -298,7 +298,7 @@ class RunManaged(Run):
     def _tensorboard_callback(self, logdir, save=None):
         logger.info("tensorboard callback: %s, %s", logdir, save)
         save = True if save is None else save
-        # self._backend.interface.send_output(name, data)
+        self._backend.interface.send_tbdata(logdir, save)
 
     def _set_library(self, library):
         self._wl = library

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -298,7 +298,7 @@ class RunManaged(Run):
     def _tensorboard_callback(self, logdir, save=None):
         logger.info("tensorboard callback: %s, %s", logdir, save)
         save = True if save is None else save
-        #self._backend.interface.send_output(name, data)
+        # self._backend.interface.send_output(name, data)
 
     def _set_library(self, library):
         self._wl = library

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -289,7 +289,6 @@ class RunManaged(Run):
             self._config_callback(data=self._config._as_dict())
 
         self._backend.interface.send_history(row, step)
-        self.summary.update(row)
 
     def _console_callback(self, name, data):
         logger.info("console callback: %s, %s", name, data)

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -421,6 +421,8 @@ class Settings(six.with_metaclass(CantTouchThis, object)):
             console = "redirect"
             if self.jupyter:
                 console = "off"
+            if self.windows:
+                console = "off"
             u["console"] = console
 
         # For code saving, only allow env var override if value from server is true, or

--- a/wandb/sdk_py27/wandb_init.py
+++ b/wandb/sdk_py27/wandb_init.py
@@ -94,8 +94,6 @@ class _WandbInit(object):
             "allow_val_change",
             "resume",
             "force",
-            "tensorboard",
-            "sync_tensorboard",
         )
         for key in unsupported:
             val = kwargs.pop(key, None)
@@ -107,6 +105,11 @@ class _WandbInit(object):
         monitor_gym = kwargs.pop("monitor_gym", None)
         if monitor_gym and len(wandb.patched["gym"]) == 0:
             wandb.gym.monitor()
+
+        tensorboard = kwargs.pop("tensorboard", None)
+        sync_tensorboard = kwargs.pop("sync_tensorboard", None)
+        if tensorboard or sync_tensorboard and len(wandb.patched["tensorboard"]) == 0:
+            wandb.tensorboard.patch()
 
         # prevent setting project, entity if in sweep
         # TODO(jhr): these should be locked elements in the future or at least

--- a/wandb/sdk_py27/wandb_run.py
+++ b/wandb/sdk_py27/wandb_run.py
@@ -298,7 +298,7 @@ class RunManaged(Run):
     def _tensorboard_callback(self, logdir, save=None):
         logger.info("tensorboard callback: %s, %s", logdir, save)
         save = True if save is None else save
-        # self._backend.interface.send_output(name, data)
+        self._backend.interface.send_tbdata(logdir, save)
 
     def _set_library(self, library):
         self._wl = library

--- a/wandb/sdk_py27/wandb_run.py
+++ b/wandb/sdk_py27/wandb_run.py
@@ -289,7 +289,6 @@ class RunManaged(Run):
             self._config_callback(data=self._config._as_dict())
 
         self._backend.interface.send_history(row, step)
-        self.summary.update(row)
 
     def _console_callback(self, name, data):
         logger.info("console callback: %s, %s", name, data)

--- a/wandb/sdk_py27/wandb_run.py
+++ b/wandb/sdk_py27/wandb_run.py
@@ -292,8 +292,13 @@ class RunManaged(Run):
         self.summary.update(row)
 
     def _console_callback(self, name, data):
-        logger.info("callback: %s, %s", name, data)
+        logger.info("console callback: %s, %s", name, data)
         self._backend.interface.send_output(name, data)
+
+    def _tensorboard_callback(self, logdir, save=None):
+        logger.info("tensorboard callback: %s, %s", logdir, save)
+        save = True if save is None else save
+        # self._backend.interface.send_output(name, data)
 
     def _set_library(self, library):
         self._wl = library

--- a/wandb/sdk_py27/wandb_settings.py
+++ b/wandb/sdk_py27/wandb_settings.py
@@ -418,6 +418,8 @@ class Settings(six.with_metaclass(CantTouchThis, object)):
             console = "redirect"
             if self.jupyter:
                 console = "off"
+            if self.windows:
+                console = "off"
             u["console"] = console
 
         # For code saving, only allow env var override if value from server is true, or


### PR DESCRIPTION
This is ready to go when regressions pass: :)
 ./cling-regression.sh --cli_branch feature/tensorboard --spec wandb-examples-tensorboard

TODO: (in a follow up PR)
- [ ] Detect tf1 situations that we cant handle (right now we patch tensorboard but it doesnt get called)
- [ ] Try on all tf, pyt, and some tensorboardX situations?  make sure we have telemetry for failed environments (sentry?)
- [x] Add proto message for watching tb dirs
- [x] Implement the watcher
- [x] Save tensorboard files
- [x] Add cleanup routines
- [x] Add event consumer
- [x] Implement the summary -> history saving logic
- [ ] Figure out what needs to be done with reinit runs?  reset?
- [ ] Might be able to support tf1.15+ with a bit more work
- [ ] Move step calculation into internal process
- [ ] Support plugin images
- [ ] Add synchronous summary query interface in user process
- [ ] Add checks for local vs remote (when we have a chance to test remote files)
- [ ] Add unittests for watcher

Regression is basically passing: (except for things listed above that are not correct and test issues)
https://app.wandb.ai/jeffr/regression/groups/20200804-0.0.39-feature_tensorboard-a849f62-v257oz