### PR TITLE
Wb 3052 config_exclude_keys and config_include_keys

### DIFF
--- a/tests/wandb_integration_test.py
+++ b/tests/wandb_integration_test.py
@@ -12,7 +12,7 @@ import os
 
 # TODO: better debugging, if the backend process fails to start we currently
 # don't get any debug information even in the internal logs.  For now I'm writing
-# logs from all tests that use test_settings to tests/logs/TEST_NAME.  If you're 
+# logs from all tests that use test_settings to tests/logs/TEST_NAME.  If you're
 # having tests just hang forever, I suggest running test/test_sender to see backend
 # errors until we ensure we propogate the errors up.
 
@@ -26,10 +26,10 @@ def test_resume_allow_success(live_mock_server, test_settings):
     wandb.join()
     server_ctx = live_mock_server.get_ctx()
     print("CTX", server_ctx)
-    first_stream_hist = server_ctx["file_stream"][0]['files']['wandb-history.jsonl']
+    first_stream_hist = server_ctx["file_stream"][0]["files"]["wandb-history.jsonl"]
     print(first_stream_hist)
     assert first_stream_hist["offset"] == 15
-    assert json.loads(first_stream_hist['content'][0])["_step"] == 16
+    assert json.loads(first_stream_hist["content"][0])["_step"] == 16
     # TODO: test _runtime offset setting
     # TODO: why no event stream?
     # assert first_stream['files']['wandb-events.jsonl'] == {
@@ -66,3 +66,45 @@ def test_resume_auto_failure(live_mock_server, test_settings):
     assert run.id == "resumeme"
     run.join(exit_code=3)
     assert os.path.exists(test_settings.resume_fname)
+
+
+def test_include_exclude_config_keys(live_mock_server, test_settings):
+    config = {
+        "foo": 1,
+        "bar": 2,
+        "baz": 3,
+    }
+    run = wandb.init(
+        reinit=True,
+        resume=True,
+        settings=test_settings,
+        config=config,
+        config_exclude_keys=("bar",),
+    )
+
+    assert run.config["foo"] == 1
+    assert run.config["baz"] == 3
+    assert "bar" not in run.config
+    run.join()
+
+    run = wandb.init(
+        reinit=True,
+        resume=True,
+        settings=test_settings,
+        config=config,
+        config_include_keys=("bar",),
+    )
+    assert run.config["bar"] == 2
+    assert "foo" not in run.config
+    assert "baz" not in run.config
+    run.join()
+
+    with pytest.raises(wandb.errors.error.UsageError):
+        run = wandb.init(
+            reinit=True,
+            resume=True,
+            settings=test_settings,
+            config=config,
+            config_exclude_keys=("bar",),
+            config_include_keys=("bar",),
+        )

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -44,6 +44,7 @@ setup = wandb_sdk.setup
 save = wandb_sdk.save
 watch = wandb_sdk.watch
 login = wandb_sdk.login
+helper = wandb_sdk.helper
 Artifact = wandb_sdk.Artifact
 Settings = wandb_sdk.Settings
 

--- a/wandb/sdk/__init__.py
+++ b/wandb/sdk/__init__.py
@@ -3,6 +3,7 @@
 module sdk
 """
 
+from . import wandb_helper as helper  # noqa: F401
 from .wandb_artifacts import Artifact  # noqa: F401
 from .wandb_config import Config  # noqa: F401
 from .wandb_history import History  # noqa: F401

--- a/wandb/sdk/wandb_config.py
+++ b/wandb/sdk/wandb_config.py
@@ -3,14 +3,14 @@
 config.
 """
 
-import inspect
 import logging
-import types
 
 import six
 from wandb.lib.config import ConfigError
 from wandb.lib.term import terminfo
 from wandb.util import json_friendly
+
+from .wandb_helper import parse_config
 
 try:
     # Since python 3
@@ -20,41 +20,6 @@ except ImportError:
     from collections import Sequence
 
 logger = logging.getLogger("wandb")
-
-
-def parse_config(params):
-    if isinstance(params, dict):
-        return params
-
-    # Handle some cases where params is not a dictionary
-    # by trying to convert it into a dictionary
-    meta = inspect.getmodule(params)
-    if meta:
-        is_tf_flags_module = (
-            isinstance(params, types.ModuleType)
-            and meta.__name__ == "tensorflow.python.platform.flags"  # noqa: W503
-        )
-        if is_tf_flags_module or meta.__name__ == "absl.flags":
-            params = params.FLAGS
-            meta = inspect.getmodule(params)
-
-    # newer tensorflow flags (post 1.4) uses absl.flags
-    if meta and meta.__name__ == "absl.flags._flagvalues":
-        params = {name: params[name].value for name in dir(params)}
-    elif "__flags" in vars(params):
-        # for older tensorflow flags (pre 1.4)
-        if not "__parsed" not in vars(params):
-            params._parse_flags()
-        params = vars(params)["__flags"]
-    elif not hasattr(params, "__dict__"):
-        raise TypeError("config must be a dict or have a __dict__ attribute.")
-    else:
-        # params is a Namespace object (argparse)
-        # or something else
-        params = vars(params)
-
-    # assume argparse Namespace
-    return params
 
 
 # TODO(jhr): consider a callback for persisting changes?

--- a/wandb/sdk/wandb_config.py
+++ b/wandb/sdk/wandb_config.py
@@ -99,6 +99,9 @@ class Config(object):
     def __getattr__(self, key):
         return self.__getitem__(key)
 
+    def __contains__(self, key):
+        return key in self._items
+
     def _update(self, d, allow_val_change=False):
         parsed_dict = parse_config(d)
         sanitized = self._sanitize_dict(parsed_dict)

--- a/wandb/sdk/wandb_helper.py
+++ b/wandb/sdk/wandb_helper.py
@@ -1,0 +1,55 @@
+import inspect
+import types
+
+import six
+from wandb.errors.error import UsageError
+
+
+def parse_config(params, exclude=None, include=None):
+    if exclude and include:
+        raise UsageError("Expected at most only one of exclude or include")
+
+    params = _to_dict(params)
+    if include:
+        params = {key: value for key, value in six.iteritems(params) if key in include}
+    if exclude:
+        params = {
+            key: value for key, value in six.iteritems(params) if key not in exclude
+        }
+
+    return params
+
+
+def _to_dict(params):
+    if isinstance(params, dict):
+        return params
+
+    # Handle some cases where params is not a dictionary
+    # by trying to convert it into a dictionary
+    meta = inspect.getmodule(params)
+    if meta:
+        is_tf_flags_module = (
+            isinstance(params, types.ModuleType)
+            and meta.__name__ == "tensorflow.python.platform.flags"  # noqa: W503
+        )
+        if is_tf_flags_module or meta.__name__ == "absl.flags":
+            params = params.FLAGS
+            meta = inspect.getmodule(params)
+
+    # newer tensorflow flags (post 1.4) uses absl.flags
+    if meta and meta.__name__ == "absl.flags._flagvalues":
+        params = {name: params[name].value for name in dir(params)}
+    elif "__flags" in vars(params):
+        # for older tensorflow flags (pre 1.4)
+        if not "__parsed" not in vars(params):
+            params._parse_flags()
+        params = vars(params)["__flags"]
+    elif not hasattr(params, "__dict__"):
+        raise TypeError("config must be a dict or have a __dict__ attribute.")
+    else:
+        # params is a Namespace object (argparse)
+        # or something else
+        params = vars(params)
+
+    # assume argparse Namespace
+    return params

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -11,7 +11,7 @@ import os
 import time
 import traceback
 
-from six import raise_from, iteritems
+from six import iteritems, raise_from
 import wandb
 from wandb.backend.backend import Backend
 from wandb.errors.error import UsageError
@@ -20,7 +20,7 @@ from wandb.lib import filesystem, module, reporting
 from wandb.old import io_wrap
 from wandb.util import sentry_exc
 
-from .wandb_config import parse_config
+from .wandb_helper import parse_config
 from .wandb_run import Run, RunDummy, RunManaged
 from .wandb_settings import Settings
 
@@ -82,11 +82,21 @@ class _WandbInit(object):
         config_include_keys = kwargs.pop("config_include_keys", None)
         config_exclude_keys = kwargs.pop("config_exclude_keys", None)
 
-        if config_include_keys and config_exclude_keys:
-            raise UsageError(
-                "Expected at most only one of config_include_keys or config_exclude_keys"
+        if config_include_keys or config_exclude_keys:
+            wandb.termwarn(
+                "config_include_keys and config_exclude_keys are deprecated -- instead,"
+                " use config=wandb.helper.parse_config(config_object, include=('key',))"
+                " or config=wandb.helper.parse_config(config_object, exclude=('key',))"
             )
-        init_config = parse_config(init_config)
+
+        if config_exclude_keys and config_include_keys:
+            raise UsageError(
+                "Expected at most only one of config_exclude_keys or "
+                "config_include_keys"
+            )
+        init_config = parse_config(
+            init_config, include=config_include_keys, exclude=config_exclude_keys
+        )
         if config_include_keys:
             init_config = {
                 key: value

--- a/wandb/sdk_py27/__init__.py
+++ b/wandb/sdk_py27/__init__.py
@@ -3,6 +3,7 @@
 module sdk
 """
 
+from . import wandb_helper as helper  # noqa: F401
 from .wandb_artifacts import Artifact  # noqa: F401
 from .wandb_config import Config  # noqa: F401
 from .wandb_history import History  # noqa: F401

--- a/wandb/sdk_py27/wandb_helper.py
+++ b/wandb/sdk_py27/wandb_helper.py
@@ -1,0 +1,55 @@
+import inspect
+import types
+
+import six
+from wandb.errors.error import UsageError
+
+
+def parse_config(params, exclude=None, include=None):
+    if exclude and include:
+        raise UsageError("Expected at most only one of exclude or include")
+
+    params = _to_dict(params)
+    if include:
+        params = {key: value for key, value in six.iteritems(params) if key in include}
+    if exclude:
+        params = {
+            key: value for key, value in six.iteritems(params) if key not in exclude
+        }
+
+    return params
+
+
+def _to_dict(params):
+    if isinstance(params, dict):
+        return params
+
+    # Handle some cases where params is not a dictionary
+    # by trying to convert it into a dictionary
+    meta = inspect.getmodule(params)
+    if meta:
+        is_tf_flags_module = (
+            isinstance(params, types.ModuleType)
+            and meta.__name__ == "tensorflow.python.platform.flags"  # noqa: W503
+        )
+        if is_tf_flags_module or meta.__name__ == "absl.flags":
+            params = params.FLAGS
+            meta = inspect.getmodule(params)
+
+    # newer tensorflow flags (post 1.4) uses absl.flags
+    if meta and meta.__name__ == "absl.flags._flagvalues":
+        params = {name: params[name].value for name in dir(params)}
+    elif "__flags" in vars(params):
+        # for older tensorflow flags (pre 1.4)
+        if not "__parsed" not in vars(params):
+            params._parse_flags()
+        params = vars(params)["__flags"]
+    elif not hasattr(params, "__dict__"):
+        raise TypeError("config must be a dict or have a __dict__ attribute.")
+    else:
+        # params is a Namespace object (argparse)
+        # or something else
+        params = vars(params)
+
+    # assume argparse Namespace
+    return params


### PR DESCRIPTION
Implements `config_exclude_keys` and `config_include_keys` from original CLI with a deprecation warning, per https://wandb.atlassian.net/browse/WB-3052

The new helper is merged with the `parse_config` function, since in the no-optional-args case they do the same thing.