### PR TITLE
[Bugfix] Remove index check for API objects

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -562,7 +562,7 @@ class Paginator(object):
 
     def __getitem__(self, index):
         loaded = True
-        while loaded and index > len(self.objects) - 1:
+        while loaded:
             loaded = self._load_page()
         return self.objects[index]
 


### PR DESCRIPTION
I don't think we need to make this check here. Let the python stdlib make the checks on index.

This fixes the -1 issue you get on first lookup.