### PR TITLE
More login fixes

### DIFF
--- a/wandb/errors/term.py
+++ b/wandb/errors/term.py
@@ -3,6 +3,7 @@ import sys
 
 
 LOG_STRING = click.style('wandb', fg='blue', bold=True)
+LOG_STRING_NOCOLOR = 'wandb'
 ERROR_STRING = click.style('ERROR', bg='red', fg='green')
 WARN_STRING = click.style('WARNING', fg='yellow')
 PRINTED_MESSAGES = set()

--- a/wandb/lib/server.py
+++ b/wandb/lib/server.py
@@ -13,8 +13,8 @@ class ServerError(Exception):
 
 
 class Server(object):
-    def __init__(self, api=None):
-        self._api = api or InternalApi()
+    def __init__(self, api=None, settings=None):
+        self._api = api or InternalApi(default_settings=settings)
         self._error_network = None
         self._viewer = {}
         self._flags = {}

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -16,6 +16,9 @@ from wandb.lib import apikey
 
 logger = logging.getLogger("wandb")
 
+if wandb.TYPE_CHECKING:  # type: ignore
+    from typing import Dict  # noqa: F401 pylint: disable=unused-import
+
 
 def _validate_anonymous_setting(anon_str):
     return anon_str in ["must", "allow", "never"]
@@ -55,7 +58,7 @@ def _login(
             wandb.termwarn("Calling wandb.login() after wandb.init() is a no-op.")
         return True
 
-    settings = {}
+    settings_dict: Dict = {}
     api = Api()
 
     if anonymous is not None:
@@ -66,14 +69,20 @@ def _login(
                 "wandb.login(). Can be 'must', 'allow', or 'never'."
             )
             return False
-        settings.update({"anonymous": anonymous})
+        settings_dict.update({"anonymous": anonymous})
+
+    if key:
+        settings_dict.update({"api_key": key})
 
     # Note: This won't actually do anything if called from a codepath where
     # wandb.setup was previously called. If wandb.setup is called further up,
     # you must make sure the anonymous setting (and any other settings) are
     # already properly set up there.
-    wl = wandb.setup()
-    settings = _settings or wl.settings()
+    wl = wandb.setup(settings=wandb.Settings(**settings_dict))
+    wl_settings = wl.settings()
+    if _settings:
+        wl_settings._apply_settings(settings=_settings)
+    settings = wl_settings
 
     if settings._offline:
         return False

--- a/wandb/sdk/wandb_setup.py
+++ b/wandb/sdk/wandb_setup.py
@@ -89,7 +89,7 @@ class _WandbSetup__WandbSetup(object):  # noqa: N801
         _set_logger(self._early_logger)
 
         # Have to load viewer before setting up settings.
-        self._load_viewer()
+        self._load_viewer(settings=settings)
 
         self._settings_setup(settings, self._early_logger)
         self._settings.freeze()
@@ -150,8 +150,8 @@ class _WandbSetup__WandbSetup(object):  # noqa: N801
     def _get_user_flags(self):
         return self._server._flags
 
-    def _load_viewer(self):
-        s = server.Server()
+    def _load_viewer(self, settings=None):
+        s = server.Server(settings=settings)
         s.query_with_timeout()
         self._server = s
         # if self.mode != "dryrun" and not self._api.disabled() and self._api.api_key:

--- a/wandb/sdk_py27/wandb_setup.py
+++ b/wandb/sdk_py27/wandb_setup.py
@@ -89,7 +89,7 @@ class _WandbSetup__WandbSetup(object):  # noqa: N801
         _set_logger(self._early_logger)
 
         # Have to load viewer before setting up settings.
-        self._load_viewer()
+        self._load_viewer(settings=settings)
 
         self._settings_setup(settings, self._early_logger)
         self._settings.freeze()
@@ -150,8 +150,8 @@ class _WandbSetup__WandbSetup(object):  # noqa: N801
     def _get_user_flags(self):
         return self._server._flags
 
-    def _load_viewer(self):
-        s = server.Server()
+    def _load_viewer(self, settings=None):
+        s = server.Server(settings=settings)
         s.query_with_timeout()
         self._server = s
         # if self.mode != "dryrun" and not self._api.disabled() and self._api.api_key:


### PR DESCRIPTION
This is getting us closer to where we need to be.  The login refactor wont be so bad at this point.

The key part of this is making sure the wandb.setup singleton gets these early login flags.    The way things were written it is too easy to assume you have the unified settings state.

There are definitely still issues hiding...  Like if in a notebook you do:
wandb.login(key="badkeey")
Then
wandb.login(key="goodkey")

this is because the singleton settings object is frozen and cant be updated with the goodkey.   I think this should wait to bee fixed up later