### PR TITLE
fix wb-3383

### DIFF
--- a/wandb/interface/interface.py
+++ b/wandb/interface/interface.py
@@ -515,10 +515,7 @@ class BackendSender(object):
         req = self._make_record(run=run)
         resp = self._communicate(req, timeout=timeout)
         if resp is None:
-            # TODO: friendlier error message here
-            raise wandb.Error(
-                "Couldn't communicate with backend after %s seconds" % timeout
-            )
+            return
         assert resp.run_result
         return resp.run_result
 
@@ -587,7 +584,9 @@ class BackendSender(object):
         check_version = wandb_internal_pb2.CheckVersionRequest()
         rec = self._make_request(check_version=check_version)
         result = self._communicate(rec)
-        return result
+        if result is None:
+            return
+        return result.response.check_version_response
 
     def communicate_run_start(self):
         run_start = wandb_internal_pb2.RunStartRequest()

--- a/wandb/interface/interface.py
+++ b/wandb/interface/interface.py
@@ -515,6 +515,7 @@ class BackendSender(object):
         req = self._make_record(run=run)
         resp = self._communicate(req, timeout=timeout)
         if resp is None:
+            # Note: timeouts handled by callers: wandb_init.py
             return
         assert resp.run_result
         return resp.run_result
@@ -585,6 +586,7 @@ class BackendSender(object):
         rec = self._make_request(check_version=check_version)
         result = self._communicate(rec)
         if result is None:
+            # Note: timeouts handled by callers: wandb_init.py
             return
         return result.response.check_version_response
 

--- a/wandb/internal/handler.py
+++ b/wandb/internal/handler.py
@@ -9,8 +9,7 @@ import numbers
 import os
 
 import six
-import wandb
-from wandb.internal import meta, sample, stats, update
+from wandb.internal import meta, sample, stats
 from wandb.internal import tb_watcher
 from wandb.lib import proto_util
 from wandb.proto import wandb_internal_pb2
@@ -190,12 +189,7 @@ class HandleManager(object):
         self._dispatch_record(record)
 
     def handle_request_check_version(self, record):
-        result = wandb_internal_pb2.Result(uuid=record.uuid)
-        current_version = wandb.__version__
-        message = update.check_available(current_version)
-        if message:
-            result.response.check_version_response.message = message
-        self._result_q.put(result)
+        self._dispatch_record(record)
 
     def handle_request_run_start(self, record):
         run_start = record.request.run_start

--- a/wandb/internal/update.py
+++ b/wandb/internal/update.py
@@ -1,7 +1,6 @@
 from pkg_resources import parse_version
 import requests
 import wandb
-import threading
 
 
 def _find_available(current_version):
@@ -15,7 +14,7 @@ def _find_available(current_version):
         data = data.json()
         latest_version = data["info"]["version"]
         release_list = data["releases"].keys()
-    except Exception as e:
+    except Exception:
         # Any issues whatsoever, just skip the latest version check.
         return
 

--- a/wandb/internal/update.py
+++ b/wandb/internal/update.py
@@ -2,66 +2,20 @@ from pkg_resources import parse_version
 import requests
 import wandb
 import threading
-from wandb.internal import internal_util
-
-
-class _Future(object):
-    def __init__(self):
-        self._object = None
-        self._object_ready = threading.Event()
-        self._lock = threading.Lock()
-
-    def get(self, timeout=None):
-        is_set = self._object_ready.wait(timeout)
-        if is_set:
-            if self._object:
-                return self._object
-            if self._except:
-                raise self._except
-        return None
-
-    def _set_object(self, obj):
-        self._object = obj
-        self._object_ready.set()
-
-    def _set_exception(self, exc):
-        self._except = exc
-        self._object_ready.set()
-
-
-class AsyncCall(threading.Thread):
-    def __init__(func):
-        self._func = func
-        self._future = _Future()
-        self.start()
-        return self._future
-
-    def run(self):
-        try:
-            ret = self._func()
-        except Exception as e:
-            self._future._set_exception(e)
-        else:
-            self._future._set_object(ret)
 
 
 def _find_available(current_version):
-    timeout = 2  # Two seconds.
     pypi_url = "https://pypi.org/pypi/%s/json" % wandb._wandb_module
-    request_thread = RequestURLThread(pypi_url, timeout=timeout)
-    request_thread.start()
-    async_call = AsyncCall(lambda: requests.get(pypi_url, timeout=timeout).json())
 
     try:
-        async_requests_get = AsyncCall(requests.get)
-        task = async_requests_get(pypi_url, timeout=timeout)
-        task.wait()
-        if task.done():
-            data = task.result()
-        data = requests.get(pypi_url, timeout=timeout).json()
+        async_requests_get = wandb.util.async_call(requests.get, timeout=5)
+        data, thread = async_requests_get(pypi_url, timeout=3)
+        if not data or isinstance(data, Exception):
+            return
+        data = data.json()
         latest_version = data["info"]["version"]
         release_list = data["releases"].keys()
-    except Exception:
+    except Exception as e:
         # Any issues whatsoever, just skip the latest version check.
         return
 

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -382,19 +382,20 @@ class _WandbInit(object):
             run._set_run_obj_offline(run_proto)
         else:
             ret = backend.interface.communicate_check_version()
-            if ret and ret.response and ret.response.check_version_response:
-                message = ret.response.check_version_response.message
-                if message:
-                    wandb.termlog(message)
+            if ret and ret.message:
+                wandb.termlog(ret.message)
             ret = backend.interface.communicate_run(run, timeout=30)
-            # TODO: fail on more errors, check return type
-            # TODO: make the backend log stacktraces on catostrophic failure
-            if ret.HasField("error"):
+            error_message = None
+            if not ret:
+                error_message = "Error communicating with backend"
+            if ret and ret.error:
+                error_message = ret.error.message
+            if error_message:
                 # Shutdown the backend and get rid of the logger
                 # we don't need to do console cleanup at this point
                 backend.cleanup()
                 self.teardown()
-                raise UsageError(ret.error.message)
+                raise UsageError(error_message)
             run._set_run_obj(ret.run)
 
         # initiate run (stats and metadata probing)

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -382,9 +382,10 @@ class _WandbInit(object):
             run._set_run_obj_offline(run_proto)
         else:
             ret = backend.interface.communicate_check_version()
-            message = ret.response.check_version_response.message
-            if message:
-                wandb.termlog(message)
+            if ret and ret.response and ret.response.check_version_response:
+                message = ret.response.check_version_response.message
+                if message:
+                    wandb.termlog(message)
             ret = backend.interface.communicate_run(run, timeout=30)
             # TODO: fail on more errors, check return type
             # TODO: make the backend log stacktraces on catostrophic failure

--- a/wandb/sdk_py27/wandb_init.py
+++ b/wandb/sdk_py27/wandb_init.py
@@ -382,19 +382,20 @@ class _WandbInit(object):
             run._set_run_obj_offline(run_proto)
         else:
             ret = backend.interface.communicate_check_version()
-            if ret and ret.response and ret.response.check_version_response:
-                message = ret.response.check_version_response.message
-                if message:
-                    wandb.termlog(message)
+            if ret and ret.message:
+                wandb.termlog(ret.message)
             ret = backend.interface.communicate_run(run, timeout=30)
-            # TODO: fail on more errors, check return type
-            # TODO: make the backend log stacktraces on catostrophic failure
-            if ret.HasField("error"):
+            error_message = None
+            if not ret:
+                error_message = "Error communicating with backend"
+            if ret and ret.error:
+                error_message = ret.error.message
+            if error_message:
                 # Shutdown the backend and get rid of the logger
                 # we don't need to do console cleanup at this point
                 backend.cleanup()
                 self.teardown()
-                raise UsageError(ret.error.message)
+                raise UsageError(error_message)
             run._set_run_obj(ret.run)
 
         # initiate run (stats and metadata probing)

--- a/wandb/sdk_py27/wandb_init.py
+++ b/wandb/sdk_py27/wandb_init.py
@@ -382,9 +382,10 @@ class _WandbInit(object):
             run._set_run_obj_offline(run_proto)
         else:
             ret = backend.interface.communicate_check_version()
-            message = ret.response.check_version_response.message
-            if message:
-                wandb.termlog(message)
+            if ret and ret.response and ret.response.check_version_response:
+                message = ret.response.check_version_response.message
+                if message:
+                    wandb.termlog(message)
             ret = backend.interface.communicate_run(run, timeout=30)
             # TODO: fail on more errors, check return type
             # TODO: make the backend log stacktraces on catostrophic failure


### PR DESCRIPTION
Tested now.

Changes:
- moved version check to sender (since it can block) handler shouldnt ever block
- fixed how we handle wandb.init() failures better, still needs more cleanup
- make sure version check has a thread so it can timeout when DNS hangs
