### PR TITLE
Tensorboard sync handles s3/gcs files!

### DIFF
--- a/wandb/integration/tensorboard/monkeypatch.py
+++ b/wandb/integration/tensorboard/monkeypatch.py
@@ -7,7 +7,6 @@ import wandb
 
 TENSORBOARD_C_MODULE = "tensorflow.python.ops.gen_summary_ops"
 TENSORBOARD_PYTORCH_MODULE = "tensorboard.summary.writer.event_file_writer"
-REMOTE_FILE_TOKEN = "://"
 
 
 def patch(save=None, tensorboardX=None, pytorch=None):
@@ -63,7 +62,4 @@ def _patch_nontensorflow(writer, module, save=None):
 
 
 def _notify_tensorboard_logdir(logdir, save=None):
-    if REMOTE_FILE_TOKEN in logdir:
-        wandb.termerror("Can not handle tensorboard_sync remote files: %s" % logdir)
-        return
     wandb.run._tensorboard_callback(logdir, save=save)

--- a/wandb/internal/handler.py
+++ b/wandb/internal/handler.py
@@ -44,7 +44,6 @@ class HandleManager(object):
         assert record_type
         handler_str = "handle_" + record_type
         handler = getattr(self, handler_str, None)
-        logger.debug("handle: {}".format(record_type))
         assert handler, "unknown handle: {}".format(handler_str)
         handler(record)
 

--- a/wandb/internal/stats.py
+++ b/wandb/internal/stats.py
@@ -81,7 +81,8 @@ class SystemStats(object):
             self._shutdown = False
             self._thread = threading.Thread(target=self._thread_body)
             self._thread.daemon = True
-        self._thread.start()
+        if not self._thread.is_alive():
+            self._thread.start()
 
     @property
     def proc(self):


### PR DESCRIPTION
Turned out to be pretty simple.  It currently requires having tensorflow installed but this should cover TPU logging.  Also fixed a nasty bug where we always delayed tensorboard metrics by 10 seconds and caused the process to hang for 10 seconds on finish.  Now we just wait for 10 seconds from the start of the process to log events.